### PR TITLE
Fix jq errors in prerelease script

### DIFF
--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -12,11 +12,10 @@ sudo -u deck mkdir -p ${HOMEBREW_FOLDER}/services
 sudo -u deck mkdir -p ${HOMEBREW_FOLDER}/plugins
 
 # Download latest release and install it
-RELEASES="$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases')"
-RELEASE="$($RELEASES | jq -r "first(.[] | select(.prerelease == "true"))")"
-VERSION="$($RELEASE | jq -r ".tag_name")"
-DOWNLOADURL="$($RELEASE | jq -r ".assets[].browser_download_url")"
-# printf "DOWNLOADURL=$DOWNLOADURL\n"
+RELEASE="$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "true"))")"
+VERSION="$(jq -r ".tag_name" <<< $RELEASE)"
+DOWNLOADURL="$(jq -r ".assets[].browser_download_url" <<< $RELEASE)"
+
 curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -12,10 +12,10 @@ sudo -u deck mkdir -p ${HOMEBREW_FOLDER}/services
 sudo -u deck mkdir -p ${HOMEBREW_FOLDER}/plugins
 
 # Download latest release and install it
-RELEASE="$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "true"))")"
-VERSION="$(jq -r ".tag_name" <<< $RELEASE)"
-DOWNLOADURL="$(jq -r ".assets[].browser_download_url" <<< $RELEASE)"
+RELEASE=$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "true"))")
+read VERSION DOWNLOADURL < <(echo $(jq -r '.tag_name, .assets[].browser_download_url' <<< ${RELEASE}))
 
+printf "Installing version %s...\n" "${VERSION}"
 curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version


### PR DESCRIPTION
The current https://raw.githubusercontent.com/SteamDeckHomebrew/decky-loader/main/dist/install_prerelease.sh script doesn't work and errors out when trying to execute.

```
(deck@breezydeck ~)$ ./install_prerelease.sh
Installing Steam Deck Plugin Loader pre-release...
./install_prerelease.sh: line 16: [: too many arguments
curl: no URL specified!
curl: try 'curl --help' for more information
```

This is a quick fix to pass in the variables to jq correctly to rectify this issue.