### PR TITLE
Readme.md references incorrect github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Keep an eye on the [Wiki](https://deckbrew.xyz) for more information about Plugi
 6. Make sure you have a password set with the "passwd" command in terminal to install it ([YouTube Guide](https://www.youtube.com/watch?v=1vOMYGj22rQ)).
 7. Open a terminal and paste the following command into it:
     - For the latest pre-release:
-        - `curl -L https://github.com/SteamDeckHomebrew/PluginLoader/raw/main/dist/install_prerelease.sh | sh`
+        - `curl -L https://github.com/SteamDeckHomebrew/decky-loader/raw/main/dist/install_prerelease.sh | sh`
     - For testers/plugin developers:
-        - `curl -L https://github.com/SteamDeckHomebrew/PluginLoader/raw/main/dist/install_prerelease.sh | sh`
+        - `curl -L https://github.com/SteamDeckHomebrew/decky-loader/raw/main/dist/install_prerelease.sh | sh`
         - [Wiki Link](https://deckbrew.xyz/en/loader-dev/development)
     - For the legacy version (unsupported):
-        - `curl -L https://github.com/SteamDeckHomebrew/PluginLoader/raw/legacy/dist/install_release.sh | sh`
+        - `curl -L https://github.com/SteamDeckHomebrew/decky-loader/raw/legacy/dist/install_release.sh | sh`
 7. Done! Reboot back into Gaming mode and enjoy your plugins!
 
 ### Install/Uninstall Plugins


### PR DESCRIPTION
Currently, the links for install/uninstall scripts in the readme still refer to the PluginLoader repo, this can cause confusion for some who are trying to install the plugin loader but using the wrong link