### PR TITLE
Add CEF Remote Debugging toggle

### DIFF
--- a/backend/helpers.py
+++ b/backend/helpers.py
@@ -65,26 +65,16 @@ def get_user_group() -> str:
         raise ValueError("helpers.get_user_group method called before group variable was set. Run helpers.set_user_group first.")
     return group
 
-async def is_systemd_unit_enabled(unit_name: str) -> bool:
-    res = subprocess.run(["systemctl", "is-enabled", unit_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    return res.returncode == 0
-
 async def is_systemd_unit_active(unit_name: str) -> bool:
     res = subprocess.run(["systemctl", "is-active", unit_name], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     return res.returncode == 0
 
-async def disable_systemd_unit(unit_name: str, stop: bool = False) -> subprocess.CompletedProcess:
-    cmd = ["systemctl", "disable", unit_name]
-
-    if stop:
-        cmd.insert(2, "--now")
+async def stop_systemd_unit(unit_name: str) -> subprocess.CompletedProcess:
+    cmd = ["systemctl", "stop", unit_name]
 
     return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
-async def enable_systemd_unit(unit_name: str, stop: bool = False) -> subprocess.CompletedProcess:
-    cmd = ["systemctl", "enable", unit_name]
-
-    if stop:
-        cmd.insert(2, "--now")
+async def start_systemd_unit(unit_name: str) -> subprocess.CompletedProcess:
+    cmd = ["systemctl", "start", unit_name]
 
     return subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from subprocess import call
 
 # local modules
 from browser import PluginBrowser
-from helpers import csrf_middleware, get_csrf_token, get_user, get_user_group, set_user, set_user_group, disable_systemd_unit, REMOTE_DEBUGGER_UNIT
+from helpers import csrf_middleware, get_csrf_token, get_user, get_user_group, set_user, set_user_group, stop_systemd_unit, REMOTE_DEBUGGER_UNIT
 from injector import inject_to_tab, tab_has_global_var
 from loader import Loader
 from updater import Updater
@@ -67,7 +67,7 @@ class PluginManager:
             self.web_app.on_startup.append(chown_plugin_dir)
         self.loop.create_task(self.loader_reinjector())
         self.loop.create_task(self.load_plugins())
-        self.loop.create_task(disable_systemd_unit(REMOTE_DEBUGGER_UNIT, True))
+        self.loop.create_task(stop_systemd_unit(REMOTE_DEBUGGER_UNIT))
         self.loop.set_exception_handler(self.exception_handler)
         self.web_app.add_routes([get("/auth/token", self.get_auth_token)])
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from subprocess import call
 
 # local modules
 from browser import PluginBrowser
-from helpers import csrf_middleware, get_csrf_token, get_user, get_user_group, set_user, set_user_group
+from helpers import csrf_middleware, get_csrf_token, get_user, get_user_group, set_user, set_user_group, disable_systemd_unit, REMOTE_DEBUGGER_UNIT
 from injector import inject_to_tab, tab_has_global_var
 from loader import Loader
 from updater import Updater
@@ -67,6 +67,7 @@ class PluginManager:
             self.web_app.on_startup.append(chown_plugin_dir)
         self.loop.create_task(self.loader_reinjector())
         self.loop.create_task(self.load_plugins())
+        self.loop.create_task(disable_systemd_unit(REMOTE_DEBUGGER_UNIT, True))
         self.loop.set_exception_handler(self.exception_handler)
         self.web_app.add_routes([get("/auth/token", self.get_auth_token)])
 

--- a/backend/utilities.py
+++ b/backend/utilities.py
@@ -5,6 +5,7 @@ from aiohttp import ClientSession, web
 
 from injector import inject_to_tab
 import helpers
+import subprocess
 
 class Utilities:
     def __init__(self, context) -> None:
@@ -16,7 +17,10 @@ class Utilities:
             "confirm_plugin_install": self.confirm_plugin_install,
             "execute_in_tab": self.execute_in_tab,
             "inject_css_into_tab": self.inject_css_into_tab,
-            "remove_css_from_tab": self.remove_css_from_tab
+            "remove_css_from_tab": self.remove_css_from_tab,
+            "allow_remote_debugging": self.allow_remote_debugging,
+            "disallow_remote_debugging": self.disallow_remote_debugging,
+            "remote_debugging_allowed": self.remote_debugging_allowed
         }
 
         if context:
@@ -133,3 +137,15 @@ class Utilities:
                 "success": False,
                 "result": e
             }
+
+
+    async def remote_debugging_allowed(self):
+        return await helpers.is_systemd_unit_enabled(helpers.REMOTE_DEBUGGER_UNIT) or await helpers.is_systemd_unit_active(helpers.REMOTE_DEBUGGER_UNIT)
+
+    async def allow_remote_debugging(self):
+        await helpers.enable_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT, True)
+        return True
+
+    async def disallow_remote_debugging(self):
+        await helpers.disable_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT, True)
+        return True

--- a/backend/utilities.py
+++ b/backend/utilities.py
@@ -140,12 +140,12 @@ class Utilities:
 
 
     async def remote_debugging_allowed(self):
-        return await helpers.is_systemd_unit_enabled(helpers.REMOTE_DEBUGGER_UNIT) or await helpers.is_systemd_unit_active(helpers.REMOTE_DEBUGGER_UNIT)
+        return await helpers.is_systemd_unit_active(helpers.REMOTE_DEBUGGER_UNIT)
 
     async def allow_remote_debugging(self):
-        await helpers.enable_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT, True)
+        await helpers.start_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT)
         return True
 
     async def disallow_remote_debugging(self):
-        await helpers.disable_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT, True)
+        await helpers.stop_systemd_unit(helpers.REMOTE_DEBUGGER_UNIT)
         return True

--- a/frontend/src/components/settings/pages/general/RemoteDebugging.tsx
+++ b/frontend/src/components/settings/pages/general/RemoteDebugging.tsx
@@ -1,0 +1,34 @@
+import { Field, ToggleField } from 'decky-frontend-lib';
+import { useEffect, useState } from 'react';
+import { FaBug } from 'react-icons/fa';
+
+export default function RemoteDebuggingSettings() {
+  const [allowRemoteDebugging, setAllowRemoteDebugging] = useState<boolean>(false);
+  useEffect(() => {
+    (async () => {
+      const res = (await window.DeckyPluginLoader.callServerMethod('remote_debugging_allowed')) as { result: boolean };
+      setAllowRemoteDebugging(res.result);
+    })();
+  }, []);
+
+  return (
+    <Field
+      label="Allow Remote CEF Debugging"
+      description={
+        <span style={{ whiteSpace: 'pre-line' }}>
+          Allow unauthenticated access to the CEF debugger to anyone in your network
+        </span>
+      }
+      icon={<FaBug style={{ display: 'block' }} />}
+    >
+      <ToggleField
+        checked={allowRemoteDebugging}
+        onChange={(toggleValue) => {
+          setAllowRemoteDebugging(toggleValue);
+          if (toggleValue) window.DeckyPluginLoader.callServerMethod('allow_remote_debugging');
+          else window.DeckyPluginLoader.callServerMethod('disallow_remote_debugging');
+        }}
+      />
+    </Field>
+  );
+}

--- a/frontend/src/components/settings/pages/general/index.tsx
+++ b/frontend/src/components/settings/pages/general/index.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { FaShapes } from 'react-icons/fa';
 
 import { installFromURL } from '../../../store/Store';
+import RemoteDebuggingSettings from './RemoteDebugging';
 import UpdaterSettings from './Updater';
 
 export default function GeneralSettings() {
@@ -20,6 +21,7 @@ export default function GeneralSettings() {
         />
       </Field> */}
       <UpdaterSettings />
+      <RemoteDebuggingSettings />
       <Field
         label="Manual plugin install"
         description={<TextField label={'URL'} value={pluginURL} onChange={(e) => setPluginURL(e?.target.value)} />}


### PR DESCRIPTION
Alternative approach to #61 

This disables the `steam-web-debug-portforward.service` unit on startup, while offering a toggle in the UI which enables and starts the service.

I am personally not quite sure if enabling/disabling is the right approach, as that would be persistent, even if decky would be uninstalled. So maybe we can just start/stop it instead? Feel free to leave your thoughts here.


![Screenshot](https://user-images.githubusercontent.com/11587657/182907361-12d6907b-46bc-4b91-8997-a50a03514734.jpg)
