### PR TITLE
Remove console.log that was causing lots of log spam

### DIFF
--- a/frontend/src/router-hook.tsx
+++ b/frontend/src/router-hook.tsx
@@ -60,7 +60,6 @@ class RouterHook extends Logger {
         routeList[routerIndex] = newRouterArray;
       }
       routeList.forEach((route: Route, index: number) => {
-        console.log(route);
         const replaced = toReplace.get(route?.props?.path as string);
         if (replaced) {
           routeList[index].props.children = replaced;


### PR DESCRIPTION
I don't know if this console.log was added for a reason but it get called a lot of fills the log with various React Nodes.

Please close if the log is on purpose!