### PR TITLE
Better wrapping of plugin tags

### DIFF
--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -119,14 +119,18 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             <p className={joinClassNames(staticClasses.PanelSectionRow)}>
               <span>Author: {plugin.author}</span>
             </p>
-            <p className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)}>
-              <span>Tags:</span>
+            <p className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)} style={{
+                padding: '0 16px',
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: '5px 10px',
+              }}>
+              <span style={{padding: '5px 0'}}>Tags:</span>
               {plugin.tags.map((tag: string) => (
                 <span
                   className="deckyStoreCardTag"
                   style={{
                     padding: '5px',
-                    marginRight: '10px',
                     borderRadius: '5px',
                     background: tag == 'root' ? '#842029' : '#ACB2C947',
                   }}
@@ -140,7 +144,6 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
                   style={{
                     color: '#232120',
                     padding: '5px',
-                    marginRight: '10px',
                     borderRadius: '5px',
                     background: '#EDE841',
                   }}


### PR DESCRIPTION
Fixed the tags overlapping when they wrap into a second line

Current:
![Screen Shot 2022-08-20 at 13 54 27](https://user-images.githubusercontent.com/5168912/185763366-1725843f-770d-4613-85b2-55c96bf9ab11.png)

Proposed changes:
![Screen Shot 2022-08-19 at 18 28 23](https://user-images.githubusercontent.com/5168912/185763376-e31ab9e3-4207-40ec-9c74-46c64a771bf3.png)

Note: I have not been able to get the deck.sh script to work to deploy the modified version on my deck and I've gotten too frustrated with it for now.