### PR TITLE
set gid along with uid

### DIFF
--- a/backend/plugin.py
+++ b/backend/plugin.py
@@ -5,7 +5,7 @@ from asyncio import (Lock, get_event_loop, new_event_loop,
 from concurrent.futures import ProcessPoolExecutor
 from importlib.util import module_from_spec, spec_from_file_location
 from json import dumps, load, loads
-from os import path, setuid
+from os import path, setgid, setuid
 from signal import SIGINT, signal
 from sys import exit
 from time import time
@@ -49,6 +49,7 @@ class PluginWrapper:
         set_event_loop(new_event_loop())
         if self.passive:
             return
+        setgid(0 if "root" in self.flags else 1000)
         setuid(0 if "root" in self.flags else 1000)
         spec = spec_from_file_location("_", self.file)
         module = module_from_spec(spec)


### PR DESCRIPTION
Trying to read the contents of a `/proc/{pid}/environ` file fails within decky-loader when the UID is set but the GID is not when dropping permissions. 

I am using the proc filesystem to get the environment variable `MANGOHUD_CONFIGFILE` from the `mangoapp` process as a more reliable way to determine the configuration file location. Getting the contents as root works, but I'd rather not have a plugin run as root if it's not necessary.


### Setting just UID
``` python
Python 3.10.2 (main, Jan 15 2022, 19:56:27) [GCC 11.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> with open('/proc/62404/environ', 'r') as f:
...   _ = f.read()
... 
>>> os.setuid(1000)
>>> with open('/proc/62404/environ', 'r') as f:
...   _ = f.read()
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
PermissionError: [Errno 13] Permission denied: '/proc/62404/environ'
>>> 
```

### Setting GID and UID
``` python
Python 3.10.2 (main, Jan 15 2022, 19:56:27) [GCC 11.1.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.setgid(1000)
>>> os.setuid(1000)
>>> with open('/proc/62404/environ', 'r') as f:
...   _ = f.read()
... 
>>> ```
