### PR TITLE
(readme) Make store link go to beta.deckbrew + Change wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Keep an eye on the [Wiki](https://deckbrew.xyz) for more information about Plugi
 9. Done! Reboot back into Gaming mode and enjoy your plugins!
 
 ### Install/Uninstall Plugins
-- Using the shopping bag button in the top right corner, you can go to the offical ["Plugin Store"](https://plugins.deckbrew.xyz/)
+- Using the shopping bag button in the top right corner, you can go to the offical Plugin Store ([Web Preview](https://beta.deckbrew.xyz/)).
 - Simply copy the plugin's folder into `~/homebrew/plugins`
 - Use the settings menu to uninstall plugins, this will not remove any files made in different directories by plugins.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Keep an eye on the [Wiki](https://deckbrew.xyz) for more information about Plugi
 9. Done! Reboot back into Gaming mode and enjoy your plugins!
 
 ### Install/Uninstall Plugins
-- Using the shopping bag button in the top right corner of the plugin loader, you can go to the offical Plugin Store ([Web Preview](https://beta.deckbrew.xyz/)).
+- Using the shopping bag button in the top right corner of the plugin menu, you can go to the offical Plugin Store ([Web Preview](https://beta.deckbrew.xyz/)).
 - Simply copy the plugin's folder into `~/homebrew/plugins`
 - Use the settings menu to uninstall plugins, this will not remove any files made in different directories by plugins.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Keep an eye on the [Wiki](https://deckbrew.xyz) for more information about Plugi
 9. Done! Reboot back into Gaming mode and enjoy your plugins!
 
 ### Install/Uninstall Plugins
-- Using the shopping bag button in the top right corner, you can go to the offical Plugin Store ([Web Preview](https://beta.deckbrew.xyz/)).
+- Using the shopping bag button in the top right corner of the plugin loader, you can go to the offical Plugin Store ([Web Preview](https://beta.deckbrew.xyz/)).
 - Simply copy the plugin's folder into `~/homebrew/plugins`
 - Use the settings menu to uninstall plugins, this will not remove any files made in different directories by plugins.
 


### PR DESCRIPTION
Change the link to https://beta.deckbrew.xyz so the plugins shown actually reflect the available plugins.

Also, people are sometimes confused by the wording, and this should hopefully make it clearer that the website doesn't actually work for downloading plugins.

example of confusion in issue #179 
![image](https://user-images.githubusercontent.com/48649272/192144541-c950a2d7-7bdb-4407-9d3c-1c9f3088f786.png)