### PR TITLE
Add plugin description to Store PluginCard

### DIFF
--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -113,8 +113,8 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             }}
             className="deckyStoreCardInfo"
           >
-            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px' }}>
-              <span>Author: {plugin.author}</span>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px' marginLeft: '16px'}}>
+              <span style={{ paddingLeft: '0px' }}>Author: {plugin.author}</span>
             </p>
             <p
               className={joinClassNames(staticClasses.PanelSectionRow)}

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -116,7 +116,15 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px' }}>
               <span>Author: {plugin.author}</span>
             </p>
-            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginLeft: '16px', marginTop: '0px', marginBottom: '0px', marginRight: '16px' }}>
+            <p
+              className={joinClassNames(staticClasses.PanelSectionRow)}
+              style={{
+                marginLeft: '16px',
+                marginTop: '0px',
+                marginBottom: '0px',
+                marginRight: '16px'
+              }}
+            >
               <span style={{ paddingLeft: '0px' }}>{plugin.description}</span>
             </p>
             <p

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -113,11 +113,11 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             }}
             className="deckyStoreCardInfo"
           >
-            <p className={joinClassNames(staticClasses.PanelSectionRow)}>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style="margin-top: 0px;">
               <span>Author: {plugin.author}</span>
             </p>
-            <p className={joinClassNames(staticClasses.PanelSectionRow)}>
-              <span>{plugin.description}</span>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style="margin-left: 16px;margin-top: 0px;margin-bottom: 0px;margin-right:16px;">
+              <span style="padding-left: 0px">{plugin.description}</span>
             </p>
             <p
               className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)}

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -113,7 +113,7 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             }}
             className="deckyStoreCardInfo"
           >
-            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px' marginLeft: '16px'}}>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px', marginLeft: '16px'}}>
               <span style={{ paddingLeft: '0px' }}>Author: {plugin.author}</span>
             </p>
             <p

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -113,11 +113,11 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             }}
             className="deckyStoreCardInfo"
           >
-            <p className={joinClassNames(staticClasses.PanelSectionRow)} style="margin-top: 0px;">
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginTop: '0px' }}>
               <span>Author: {plugin.author}</span>
             </p>
-            <p className={joinClassNames(staticClasses.PanelSectionRow)} style="margin-left: 16px;margin-top: 0px;margin-bottom: 0px;margin-right:16px;">
-              <span style="padding-left: 0px">{plugin.description}</span>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)} style={{ marginLeft: '16px', marginTop: '0px', marginBottom: '0px', marginRight: '16px' }}>
+              <span style={{ paddingLeft: '0px' }}>{plugin.description}</span>
             </p>
             <p
               className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)}

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -116,6 +116,9 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
             <p className={joinClassNames(staticClasses.PanelSectionRow)}>
               <span>Author: {plugin.author}</span>
             </p>
+            <p className={joinClassNames(staticClasses.PanelSectionRow)}>
+              <span>Description: {plugin.description}</span>
+            </p>
             <p
               className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)}
               style={{

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -117,7 +117,7 @@ const PluginCard: FC<PluginCardProps> = ({ plugin }) => {
               <span>Author: {plugin.author}</span>
             </p>
             <p className={joinClassNames(staticClasses.PanelSectionRow)}>
-              <span>Description: {plugin.description}</span>
+              <span>{plugin.description}</span>
             </p>
             <p
               className={joinClassNames('deckyStoreCardTagsContainer', staticClasses.PanelSectionRow)}


### PR DESCRIPTION
This PR attempts to add plugin descriptions to the deck-store like those found on the web version.

As a new Steam Deck user, I found it extremely frustrating to have to use another device to see exactly what a plugin did, if the name of the plugin didn't make it's purpose obvious.

_Unfortunately, my current env is completely Windows based so I cannot test this change locally, and setting up an Arch env in WSL2 is proving to be more time consuming than such a simple PR deserves. I would appreciate any assistance in testing this fix visually._