### PR TITLE
Fixed an issue regarding the scroll root path

### DIFF
--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -58,7 +58,7 @@ class TabsHook extends Logger {
         let node = await findScrollRoot(currentNode.sibling, iters++);
         if (node !== null) return node;
       }
-      return findScrollRoot(currentNode, iters++);
+      return await findScrollRoot(currentNode, iters++);
     }
     (async () => {
       scrollRoot = await findScrollRoot(tree, 0);

--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -49,7 +49,8 @@ class TabsHook extends Logger {
     let scrollRoot: any;
     async function findScrollRoot(currentNode: any, iters: number): Promise<any> {
       if (iters >= 30) {
-        return null;
+        await sleep(5000);
+        return await findScrollRoot(tree, 0);
       }
       currentNode = currentNode?.child;
       if (currentNode?.type?.prototype?.RemoveSmartScrollContainer) return currentNode;
@@ -62,9 +63,9 @@ class TabsHook extends Logger {
     }
     (async () => {
       scrollRoot = await findScrollRoot(tree, 0);
-      while (!scrollRoot) {
-        await sleep(5000);
-        scrollRoot = await findScrollRoot(tree, 0);
+      if (!scrollRoot) {
+        this.error('Failed to find scroll root node!');
+        return;
       }
       let newQA: any;
       let newQATabRenderer: any;
@@ -78,7 +79,7 @@ class TabsHook extends Logger {
                 this.tabRenderer = ret.props.children[1].children.type;
                 newQATabRenderer = (...args: any) => {
                   const oFilter = Array.prototype.filter;
-                  Array.prototype.filter = function(...args: any[]) {
+                  Array.prototype.filter = function (...args: any[]) {
                     if (isTabsArray(this)) {
                       self.render(this);
                     }

--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -62,7 +62,7 @@ class TabsHook extends Logger {
     }
     (async () => {
       scrollRoot = await findScrollRoot(tree, 0);
-      while (scrollRoot == null) {
+      while (!scrollRoot) {
         await sleep(5000);
         scrollRoot = await findScrollRoot(tree, 0);
       }


### PR DESCRIPTION
The scroll root's path changed in the latest Steam Client beta update. This PR makes so that Decky should be able to find the scroll root using a recursive function that goes down the sibling and child nodes. This fixes issue #197 from what I can tell. Tested personally to work on both the latest Beta update, and the stable update, and works on both.