### PR TITLE
Use a conditional while loop for when the scroll root is not found.

### DIFF
--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -72,7 +72,6 @@ class TabsHook extends Logger {
         this.log('Failed to find scroll root node, reattempting in 5 seconds');
         await sleep(5000);
         scrollRoot = await findScrollRoot(tree, 0);
-        return;
       }
       let newQA: any;
       let newQATabRenderer: any;

--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -49,8 +49,7 @@ class TabsHook extends Logger {
     let scrollRoot: any;
     async function findScrollRoot(currentNode: any, iters: number): Promise<any> {
       if (iters >= 30) {
-        await sleep(5000);
-        return await findScrollRoot(tree, 0);
+        return null;
       }
       currentNode = currentNode?.child;
       if (currentNode?.type?.prototype?.RemoveSmartScrollContainer) return currentNode;

--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -49,16 +49,22 @@ class TabsHook extends Logger {
     let scrollRoot: any;
     async function findScrollRoot(currentNode: any, iters: number): Promise<any> {
       if (iters >= 30) {
+        self.error(
+          'Scroll root was not found before hitting the recursion limit, a developer will need to increase the limit.',
+        );
         return null;
       }
       currentNode = currentNode?.child;
-      if (currentNode?.type?.prototype?.RemoveSmartScrollContainer) return currentNode;
+      if (currentNode?.type?.prototype?.RemoveSmartScrollContainer) {
+        self.log(`Scroll root was found in ${iters} recursion cycles`);
+        return currentNode;
+      }
       if (!currentNode) return null;
       if (currentNode.sibling) {
-        let node = await findScrollRoot(currentNode.sibling, iters++);
+        let node = await findScrollRoot(currentNode.sibling, iters + 1);
         if (node !== null) return node;
       }
-      return await findScrollRoot(currentNode, iters++);
+      return await findScrollRoot(currentNode, iters + 1);
     }
     (async () => {
       scrollRoot = await findScrollRoot(tree, 0);

--- a/frontend/src/tabs-hook.ts
+++ b/frontend/src/tabs-hook.ts
@@ -63,8 +63,10 @@ class TabsHook extends Logger {
     }
     (async () => {
       scrollRoot = await findScrollRoot(tree, 0);
-      if (!scrollRoot) {
-        this.error('Failed to find scroll root node!');
+      while (!scrollRoot) {
+        this.log('Failed to find scroll root node, reattempting in 5 seconds');
+        await sleep(5000);
+        scrollRoot = await findScrollRoot(tree, 0);
         return;
       }
       let newQA: any;


### PR DESCRIPTION
After diagnosing the issue regarding Decky not loading in select situations but printing the error that states it was unable to find scroll root, it appeared to be caused by the recursive function never hitting 30 levels of depth, thus it never rechecks the tree. This seems to be partially caused by TabsHook loading before the QAM has been initialized in Library Init Stage 2, which occurs randomly on occassion, and seems to be less likely to occur on Steam Decks that don't have the lock screen setup. The proposed fix is a revert of some portion of the code to where a while loop is used after the initial call attempting to get the scroll root instead of just exiting, as well as removing the portion that would continue the recursive function should 30 recursive calls be made. 

On another note, I have added some log messages regarding the recursion limits. One denotes the current level that it hits when it finds the scroll root, the other denotes that the recursion limit needs to be increased, as the max depth of the tree is now longer than the recursion call, but this should not appear currently since currently the scroll root is only around 23 levels deep right now, and the current limit is 30, which is still above the depth of the tree. The most recent update that broke Decky and is why the changes were made to how the scroll root was found were made changed the relative level from around 21 to around 23, so it may be possible that the scroll root will be on a level deeper than 30 someday.