### PR TITLE
Allow B button to close active plugin and return to menu.

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ if hasattr(sys, '_MEIPASS'):
 from asyncio import get_event_loop, sleep
 from json import dumps, loads
 from logging import DEBUG, INFO, basicConfig, getLogger
-from os import getenv, chmod
+from os import getenv, chmod, path
 from traceback import format_exc
 
 import aiohttp_cors

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -10,9 +10,16 @@ import { VFC } from 'react';
 
 import { useDeckyState } from './DeckyState';
 import NotificationBadge from './NotificationBadge';
+import { useQuickAccessVisible } from './QuickAccessVisibleState';
 
 const PluginView: VFC = () => {
   const { plugins, updates, activePlugin, setActivePlugin } = useDeckyState();
+  const visible = useQuickAccessVisible();
+
+  if (!visible) {
+    console.log('invisible');
+    return null;
+  }
 
   if (activePlugin) {
     return (

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -1,5 +1,6 @@
 import {
   ButtonItem,
+  Focusable,
   PanelSection,
   PanelSectionRow,
   joinClassNames,
@@ -13,22 +14,22 @@ import NotificationBadge from './NotificationBadge';
 import { useQuickAccessVisible } from './QuickAccessVisibleState';
 
 const PluginView: VFC = () => {
-  const { plugins, updates, activePlugin, setActivePlugin } = useDeckyState();
+  const { plugins, updates, activePlugin, setActivePlugin, closeActivePlugin } = useDeckyState();
   const visible = useQuickAccessVisible();
 
   if (!visible) {
-    console.log('invisible');
     return null;
   }
 
   if (activePlugin) {
     return (
-      <div
+      <Focusable
         className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}
         style={{ height: '100%' }}
+        onCancelButton={closeActivePlugin}
       >
         {activePlugin.content}
-      </div>
+      </Focusable>
     );
   }
   return (

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -12,44 +12,46 @@ import { VFC } from 'react';
 import { useDeckyState } from './DeckyState';
 import NotificationBadge from './NotificationBadge';
 import { useQuickAccessVisible } from './QuickAccessVisibleState';
+import TitleView from './TitleView';
 
 const PluginView: VFC = () => {
   const { plugins, updates, activePlugin, setActivePlugin, closeActivePlugin } = useDeckyState();
   const visible = useQuickAccessVisible();
 
-  if (!visible) {
-    return null;
-  }
-
   if (activePlugin) {
     return (
-      <Focusable
-        className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}
-        style={{ height: '100%' }}
-        onCancelButton={closeActivePlugin}
-      >
-        {activePlugin.content}
+      <Focusable onCancelButton={closeActivePlugin}>
+        <TitleView />
+        <div
+          className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}
+          style={{ height: '100%' }}
+        >
+          {visible && activePlugin.content}
+        </div>
       </Focusable>
     );
   }
   return (
-    <div className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}>
-      <PanelSection>
-        {plugins
-          .filter((p) => p.content)
-          .map(({ name, icon }) => (
-            <PanelSectionRow key={name}>
-              <ButtonItem layout="below" onClick={() => setActivePlugin(name)}>
-                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                  {icon}
-                  <div>{name}</div>
-                  <NotificationBadge show={updates?.has(name)} style={{ top: '-5px', right: '-5px' }} />
-                </div>
-              </ButtonItem>
-            </PanelSectionRow>
-          ))}
-      </PanelSection>
-    </div>
+    <>
+      <TitleView />
+      <div className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}>
+        <PanelSection>
+          {plugins
+            .filter((p) => p.content)
+            .map(({ name, icon }) => (
+              <PanelSectionRow key={name}>
+                <ButtonItem layout="below" onClick={() => setActivePlugin(name)}>
+                  <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    {icon}
+                    <div>{name}</div>
+                    <NotificationBadge show={updates?.has(name)} style={{ top: '-5px', right: '-5px' }} />
+                  </div>
+                </ButtonItem>
+              </PanelSectionRow>
+            ))}
+        </PanelSection>
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/components/QuickAccessVisibleState.tsx
+++ b/frontend/src/components/QuickAccessVisibleState.tsx
@@ -1,0 +1,13 @@
+import { FC, createContext, useContext } from 'react';
+
+const QuickAccessVisibleState = createContext<boolean>(true);
+
+export const useQuickAccessVisible = () => useContext(QuickAccessVisibleState);
+
+interface Props {
+  visible: boolean;
+}
+
+export const QuickAccessVisibleStateProvider: FC<Props> = ({ children, visible }) => {
+  return <QuickAccessVisibleState.Provider value={visible}>{children}</QuickAccessVisibleState.Provider>;
+};

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -17,7 +17,6 @@ import { deinitFilepickerPatches, initFilepickerPatches } from './components/mod
 import PluginInstallModal from './components/modals/PluginInstallModal';
 import NotificationBadge from './components/NotificationBadge';
 import PluginView from './components/PluginView';
-import TitleView from './components/TitleView';
 import WithSuspense from './components/WithSuspense';
 import Logger from './logger';
 import { Plugin } from './plugin';
@@ -64,7 +63,6 @@ class PluginLoader extends Logger {
       title: null,
       content: (
         <DeckyStateContextProvider deckyState={this.deckyState}>
-          <TitleView />
           <PluginView />
         </DeckyStateContextProvider>
       ),

--- a/frontend/src/tabs-hook.tsx
+++ b/frontend/src/tabs-hook.tsx
@@ -1,6 +1,7 @@
 import { Patch, QuickAccessTab, afterPatch, sleep } from 'decky-frontend-lib';
 import { memo } from 'react';
 
+import { QuickAccessVisibleStateProvider } from './components/QuickAccessVisibleState';
 import Logger from './logger';
 
 declare global {
@@ -83,17 +84,17 @@ class TabsHook extends Logger {
             if (ret) {
               if (!newQATabRenderer) {
                 this.tabRenderer = ret.props.children[1].children.type;
-                newQATabRenderer = (...args: any) => {
+                newQATabRenderer = (...qamArgs: any[]) => {
                   const oFilter = Array.prototype.filter;
                   Array.prototype.filter = function (...args: any[]) {
                     if (isTabsArray(this)) {
-                      self.render(this);
+                      self.render(this, qamArgs[0].visible);
                     }
                     // @ts-ignore
                     return oFilter.call(this, ...args);
                   };
                   // TODO remove array hack entirely and use this instead const tabs = ret.props.children.props.children[0].props.children[1].props.children[0].props.children[0].props.tabs
-                  const ret = this.tabRenderer(...args);
+                  const ret = this.tabRenderer(...qamArgs);
                   Array.prototype.filter = oFilter;
                   return ret;
                 };
@@ -135,13 +136,13 @@ class TabsHook extends Logger {
     this.tabs = this.tabs.filter((tab) => tab.id !== id);
   }
 
-  render(existingTabs: any[]) {
+  render(existingTabs: any[], visible: boolean) {
     for (const { title, icon, content, id } of this.tabs) {
       existingTabs.push({
         key: id,
         title,
         tab: icon,
-        panel: content,
+        panel: <QuickAccessVisibleStateProvider visible={visible}>{content}</QuickAccessVisibleStateProvider>,
       });
     }
   }


### PR DESCRIPTION
Also makes plugins not render unless the Quick Access Menu is visible.