### PR TITLE
Add timeout to get tabs request, wait for network online target before booting decky

### DIFF
--- a/backend/injector.py
+++ b/backend/injector.py
@@ -7,6 +7,7 @@ from typing import List
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientConnectorError
+from asyncio.exceptions import TimeoutError
 import uuid
 
 BASE_ADDRESS = "http://localhost:8080"
@@ -341,12 +342,15 @@ async def get_tabs() -> List[Tab]:
 
         while True:
             try:
-                res = await web.get(f"{BASE_ADDRESS}/json")
+                res = await web.get(f"{BASE_ADDRESS}/json", timeout=3)
             except ClientConnectorError:
                 logger.debug("ClientConnectorError excepted.")
                 logger.debug("Steam isn't available yet. Wait for a moment...")
                 logger.error(format_exc())
                 await sleep(5)
+            except TimeoutError:
+                logger.warn(f"The request to {BASE_ADDRESS}/json timed out")
+                await sleep(1)
             else:
                 break
 

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -30,6 +30,8 @@ rm -f /etc/systemd/system/plugin_loader.service
 cat > /etc/systemd/system/plugin_loader.service <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network-online.target
+Wants=network-online.target
 [Service]
 Type=simple
 User=root

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -30,6 +30,8 @@ rm -f "/etc/systemd/system/plugin_loader.service"
 cat > "/etc/systemd/system/plugin_loader.service" <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network-online.target
+Wants=network-online.target
 [Service]
 Type=simple
 User=root


### PR DESCRIPTION
Tested with the help of @nabel0

Not 100% sure on the `network-online.target`. I think this only works when any network interface is up. With wifi disabled, after a reboot, decky still boots. I seem to have a loopback network interface that goes up pretty quickly, so that may be why. Someone who knows sytemd better than me should chime in on this