### PR TITLE
Systemd service updating

### DIFF
--- a/backend/updater.py
+++ b/backend/updater.py
@@ -195,7 +195,6 @@ class Updater:
                     out.write(version)
 
                 call(['chmod', '+x', path.join(getcwd(), "PluginLoader")])
-            
                 logger.info("Updated loader installation.")
                 await tab.evaluate_js("window.DeckyUpdater.finish()", False, False)
                 await self.do_restart()

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -159,6 +159,12 @@ class Updater:
                         out.write(data)
                 except Exception as e:
                     logger.error(f"Error at %s", exc_info=e)
+                with open(path.join(getcwd(), "plugin_loader.service"), 'r') as service_file:
+                    service_data = service_file.read()
+                service_data = service_data.replace("${HOMEBREW_FOLDER}", "/home/"+helpers.get_user()+"/homebrew")
+                with open(path.join(getcwd(), "plugin_loader.service"), 'w') as service_file:
+                        service_file.write(service_data)
+                    
             logger.debug("Saved service file")
             logger.debug("Copying service file over current file.")
             shutil.copy(service_file_path, "/etc/systemd/system/plugin_loader.service")

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -168,6 +168,9 @@ class Updater:
             logger.debug("Saved service file")
             logger.debug("Copying service file over current file.")
             shutil.copy(service_file_path, "/etc/systemd/system/plugin_loader.service")
+            if not os.path.exists(path.join(getcwd(), ".systemd")):
+                os.mkdir(path.join(getcwd(), ".systemd"))
+            shutil.move(service_file_path, path.join(getcwd(), ".systemd")+"/plugin_loader.service")
             
             logger.debug("Downloading binary")
             async with web.request("GET", download_url, ssl=helpers.get_ssl_context(), allow_redirects=True) as res:

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -48,6 +48,7 @@ EOM
 
 if [[ -f "${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service" ]]; then
     printf "Grabbed latest prerelease service.\n"
+    sed -i -e "s|\${HOMEBREW_FOLDER}|${HOMEBREW_FOLDER}|" "${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service"
     cp -f "${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service" "/etc/systemd/system/plugin_loader.service"
 else
     printf "Could not curl latest prerelease systemd service, using built-in service as a backup!\n"

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -7,8 +7,8 @@ echo "Installing Steam Deck Plugin Loader pre-release..."
 USER_DIR="$(getent passwd $SUDO_USER | cut -d: -f6)"
 HOMEBREW_FOLDER="${USER_DIR}/homebrew"
 
-# # Create folder structure
-rm -rf ${HOMEBREW_FOLDER}/services
+# Create folder structure
+rm -rf "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/plugins"
 
@@ -26,8 +26,10 @@ systemctl --user disable plugin_loader 2> /dev/null
 
 systemctl stop plugin_loader 2> /dev/null
 systemctl disable plugin_loader 2> /dev/null
-rm -f "/etc/systemd/system/plugin_loader.service"
-cat > "/etc/systemd/system/plugin_loader.service" <<- EOM
+
+curl -L https://raw.githubusercontent.com/SteamDeckHomebrew/decky-loader/service-updater/dist/plugin_loader-prerelease.service  --output ${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service
+
+cat > "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
 After=network-online.target
@@ -43,6 +45,21 @@ Environment=LOG_LEVEL=DEBUG
 [Install]
 WantedBy=multi-user.target
 EOM
+
+if [[ -f "${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service" ]]; then
+    printf "Grabbed latest prerelease service.\n"
+    cp -f "${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service" "/etc/systemd/system/plugin_loader.service"
+else
+    printf "Could not curl latest prerelease systemd service, using built-in service as a backup!\n"
+    rm -f "/etc/systemd/system/plugin_loader.service"
+    cp "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" "/etc/systemd/system/plugin_loader.service"
+fi
+
+mkdir -p ${HOMEBREW_FOLDER}/services/.systemd
+cp ${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-prerelease.service
+cp ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-backup.service
+rm ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/plugin_loader-release.service
+
 systemctl daemon-reload
 systemctl start plugin_loader
 systemctl enable plugin_loader

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -59,7 +59,7 @@ fi
 mkdir -p ${HOMEBREW_FOLDER}/services/.systemd
 cp ${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-prerelease.service
 cp ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-backup.service
-rm ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/plugin_loader-release.service
+rm ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/plugin_loader-prerelease.service
 
 systemctl daemon-reload
 systemctl start plugin_loader

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -48,6 +48,7 @@ EOM
 
 if [[ -f "${HOMEBREW_FOLDER}/services/plugin_loader-release.service" ]]; then
     printf "Grabbed latest release service.\n"
+    sed -i -e "s|\${HOMEBREW_FOLDER}|${HOMEBREW_FOLDER}|" "${HOMEBREW_FOLDER}/services/plugin_loader-release.service"
     cp -f "${HOMEBREW_FOLDER}/services/plugin_loader-release.service" "/etc/systemd/system/plugin_loader.service"
 else
     printf "Could not curl latest release systemd service, using built-in service as a backup!\n"

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -26,8 +26,10 @@ systemctl --user disable plugin_loader 2> /dev/null
 
 systemctl stop plugin_loader 2> /dev/null
 systemctl disable plugin_loader 2> /dev/null
-rm -f "/etc/systemd/system/plugin_loader.service"
-cat > "/etc/systemd/system/plugin_loader.service" <<- EOM
+
+curl -L https://raw.githubusercontent.com/SteamDeckHomebrew/decky-loader/service-updater/dist/plugin_loader-release.service  --output ${HOMEBREW_FOLDER}/services/plugin_loader-release.service
+
+cat > "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
 After=network-online.target
@@ -39,9 +41,25 @@ Restart=always
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services
 Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
+Environment=LOG_LEVEL=INFO
 [Install]
 WantedBy=multi-user.target
 EOM
+
+if [[ -f "${HOMEBREW_FOLDER}/services/plugin_loader-release.service" ]]; then
+    printf "Grabbed latest release service.\n"
+    cp -f "${HOMEBREW_FOLDER}/services/plugin_loader-release.service" "/etc/systemd/system/plugin_loader.service"
+else
+    printf "Could not curl latest release systemd service, using built-in service as a backup!\n"
+    rm -f "/etc/systemd/system/plugin_loader.service"
+    cp "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" "/etc/systemd/system/plugin_loader.service"
+fi
+
+mkdir -p ${HOMEBREW_FOLDER}/services/.systemd
+cp ${HOMEBREW_FOLDER}/services/plugin_loader-release.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-release.service
+cp ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/.systemd/plugin_loader-backup.service
+rm ${HOMEBREW_FOLDER}/services/plugin_loader-backup.service ${HOMEBREW_FOLDER}/services/plugin_loader-release.service
+
 systemctl daemon-reload
 systemctl start plugin_loader
 systemctl enable plugin_loader

--- a/dist/plugin_loader-prerelease.service
+++ b/dist/plugin_loader-prerelease.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SteamDeck Plugin Loader
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=simple
+User=root
+Restart=always
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
+Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
+Environment=LOG_LEVEL=DEBUG
+[Install]
+WantedBy=multi-user.target

--- a/dist/plugin_loader-prerelease.service
+++ b/dist/plugin_loader-prerelease.service
@@ -6,9 +6,9 @@ Wants=network-online.target
 Type=simple
 User=root
 Restart=always
-ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
-WorkingDirectory=${HOMEBREW_FOLDER}/services
-Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
+ExecStart=${HOME}/homebrew/services/PluginLoader
+WorkingDirectory=${HOME}/homebrew/services
+Environment=PLUGIN_PATH=${HOME}/homebrew/plugins
 Environment=LOG_LEVEL=DEBUG
 [Install]
 WantedBy=multi-user.target

--- a/dist/plugin_loader-prerelease.service
+++ b/dist/plugin_loader-prerelease.service
@@ -6,9 +6,9 @@ Wants=network-online.target
 Type=simple
 User=root
 Restart=always
-ExecStart=${HOME}/homebrew/services/PluginLoader
-WorkingDirectory=${HOME}/homebrew/services
-Environment=PLUGIN_PATH=${HOME}/homebrew/plugins
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
+Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
 Environment=LOG_LEVEL=DEBUG
 [Install]
 WantedBy=multi-user.target

--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=SteamDeck Plugin Loader
+After=network-online.target
+Wants=network-online.target
+[Service]
+Type=simple
+User=root
+Restart=always
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
+Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
+Environment=LOG_LEVEL=INFO
+[Install]
+WantedBy=multi-user.target

--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -6,9 +6,9 @@ Wants=network-online.target
 Type=simple
 User=root
 Restart=always
-ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
-WorkingDirectory=${HOMEBREW_FOLDER}/services
-Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
+ExecStart=${HOME}/homebrew/services/PluginLoader
+WorkingDirectory=${HOME}/homebrew/services
+Environment=PLUGIN_PATH=${HOME}/homebrew/plugins
 Environment=LOG_LEVEL=INFO
 [Install]
 WantedBy=multi-user.target

--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -6,9 +6,9 @@ Wants=network-online.target
 Type=simple
 User=root
 Restart=always
-ExecStart=${HOME}/homebrew/services/PluginLoader
-WorkingDirectory=${HOME}/homebrew/services
-Environment=PLUGIN_PATH=${HOME}/homebrew/plugins
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
+Environment=PLUGIN_PATH=${HOMEBREW_FOLDER}/plugins
 Environment=LOG_LEVEL=INFO
 [Install]
 WantedBy=multi-user.target

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     }
   },
   "dependencies": {
-    "decky-frontend-lib": "^3.7.11",
+    "decky-frontend-lib": "^3.7.12",
     "react-file-icon": "^1.2.0",
     "react-icons": "^4.4.0",
     "react-markdown": "^8.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@types/react-file-icon': ^1.0.1
   '@types/react-router': 5.1.18
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: ^3.7.11
+  decky-frontend-lib: ^3.7.12
   husky: ^8.0.1
   import-sort-style-module: ^6.0.0
   inquirer: ^8.2.4
@@ -30,7 +30,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 3.7.11
+  decky-frontend-lib: 3.7.12
   react-file-icon: 1.2.0_wcqkhtmu7mswc6yz4uyexck3ty
   react-icons: 4.4.0_react@16.14.0
   react-markdown: 8.0.3_vshvapmxg47tngu7tvrsqpq55u
@@ -944,8 +944,8 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /decky-frontend-lib/3.7.11:
-    resolution: {integrity: sha512-c5/kXqCLYhCl0zC+kPJ2gTUjTp6N0zUFKzTQKVKTuQ3U+01fHAU6sUsDqudbdTNdjXiofGujMmeJqKaU2vQoXQ==}
+  /decky-frontend-lib/3.7.12:
+    resolution: {integrity: sha512-whDV9zHuEBFj17zKoT51aRcUxLvSzBNu2lc242/EO9aFFP064FVCrJu+r7CxWe0hlQ7sA4FKX1qgCwsZ6H+PZg==}
     dev: false
 
   /decode-named-character-reference/1.0.2:

--- a/frontend/src/components/settings/pages/general/BranchSelect.tsx
+++ b/frontend/src/components/settings/pages/general/BranchSelect.tsx
@@ -10,7 +10,7 @@ const logger = new Logger('BranchSelect');
 enum UpdateBranch {
   Stable,
   Prerelease,
-  Testing,
+  // Testing,
 }
 
 const BranchSelect: FunctionComponent<{}> = () => {

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -1,5 +1,4 @@
 import { Plugin } from './plugin';
-import { getSetting, setSetting } from './utils/settings';
 
 export enum Store {
   Default,

--- a/frontend/src/tabs-hook.tsx
+++ b/frontend/src/tabs-hook.tsx
@@ -1,5 +1,5 @@
 // TabsHook for versions after the Desktop merge
-import { Patch, QuickAccessTab, afterPatch, findInReactTree, findModule, sleep } from 'decky-frontend-lib';
+import { Patch, QuickAccessTab, afterPatch, findInReactTree, sleep } from 'decky-frontend-lib';
 
 import { QuickAccessVisibleStateProvider } from './components/QuickAccessVisibleState';
 import Logger from './logger';

--- a/frontend/src/tabs-hook.tsx
+++ b/frontend/src/tabs-hook.tsx
@@ -1,10 +1,8 @@
 // TabsHook for versions after the Desktop merge
 import { Patch, QuickAccessTab, afterPatch, findInReactTree, findModule, sleep } from 'decky-frontend-lib';
-import { memo } from 'react';
 
 import { QuickAccessVisibleStateProvider } from './components/QuickAccessVisibleState';
 import Logger from './logger';
-import { findSP } from './utils/windows';
 
 declare global {
   interface Window {

--- a/frontend/src/updater.ts
+++ b/frontend/src/updater.ts
@@ -1,7 +1,7 @@
 export enum Branches {
   Release,
   Prerelease,
-  Testing,
+  // Testing,
 }
 
 export interface DeckyUpdater {


### PR DESCRIPTION
With @suchmememanyskill's recent updates to help with a potential race condition between plugins and loader, users would have to re-install decky to get their systemd services updated but now updates with update the service file as well.

This has been pretty been well tested but review is still requested.