### PR TITLE
Fix for wrong path for settings json files

### DIFF
--- a/backend/helpers.py
+++ b/backend/helpers.py
@@ -1,3 +1,5 @@
+import grp
+import pwd
 import re
 import ssl
 import subprocess
@@ -55,6 +57,14 @@ def get_user() -> str:
     if user == None:
         raise ValueError("helpers.get_user method called before user variable was set. Run helpers.set_user first.")
     return user
+
+#Get the user owner of the given file path.
+def get_user_owner(file_path) -> str:
+    return pwd.getpwuid(os.stat(file_path).st_uid)[0]
+
+#Get the user group of the given file path.
+def get_user_group(file_path) -> str:
+    return grp.getgrgid(os.stat(file_path).st_gid)[0]
 
 # Set the global user group. get_user must be called first
 def set_user_group() -> str:

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -1,9 +1,8 @@
-import imp, pwd
 from json import dump, load
-from os import mkdir, path, stat, listdir, rename
+from os import mkdir, path, listdir, rename
 from shutil import chown
 
-from helpers import get_home_path, get_homebrew_path, get_user, set_user
+from helpers import get_home_path, get_homebrew_path, get_user, set_user, get_user_owner
 
 
 class SettingsManager:
@@ -24,14 +23,13 @@ class SettingsManager:
         #Copy all old settings file in the root directory to the correct folder
         for file in listdir(wrong_dir):
             if file.endswith(".json"):
-                chown(path.join(wrong_dir,file), USER, USER)
                 rename(path.join(wrong_dir,file),
                        path.join(settings_directory, file)) 
                 self.path = path.join(settings_directory, name + ".json")
                 
         
         #If the owner of the settings directory is not the user, then set it as the user:
-        if pwd.getpwuid(stat(settings_directory).st_uid)[0] != USER:
+        if get_user_owner(settings_directory) != USER:
             chown(settings_directory, USER, USER)
 
         self.settings = {}

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -10,9 +10,9 @@ class SettingsManager:
     def __init__(self, name, settings_directory = None) -> None:
         set_user()
         USER = get_user()
+        wrong_dir = get_homebrew_path(get_home_path(USER))
         if settings_directory == None:
-            settings_directory = path_join(get_homebrew_path(get_home_path(USER)), "settings")
-            wrong_dir = get_homebrew_path(get_home_path(USER))
+            settings_directory = path.join(wrong_dir, "settings")
         
         self.path = path.join(settings_directory, name + ".json")
         
@@ -24,8 +24,8 @@ class SettingsManager:
         #Copy all old settings file in the root directory to the correct folder
         for file in listdir(wrong_dir):
             if file.endswith(".json"):
-                rename(path_join(wrong_dir,file),
-                       path_join(settings_directory, file)) 
+                rename(path.join(wrong_dir,file),
+                       path.join(settings_directory, file)) 
                 self.path = path.join(settings_directory, name + ".json")
                 
         

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -24,6 +24,7 @@ class SettingsManager:
         #Copy all old settings file in the root directory to the correct folder
         for file in listdir(wrong_dir):
             if file.endswith(".json"):
+                chown(path.join(wrong_dir,file), USER, USER)
                 rename(path.join(wrong_dir,file),
                        path.join(settings_directory, file)) 
                 self.path = path.join(settings_directory, name + ".json")

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -12,22 +12,22 @@ class SettingsManager:
         wrong_dir = get_homebrew_path(get_home_path(USER))
         if settings_directory == None:
             settings_directory = path.join(wrong_dir, "settings")
-        
+
         self.path = path.join(settings_directory, name + ".json")
-        
+
         #Create the folder with the correct permission
         if not path.exists(settings_directory):
             mkdir(settings_directory)
             chown(settings_directory, USER, USER)
-        
+
         #Copy all old settings file in the root directory to the correct folder
         for file in listdir(wrong_dir):
             if file.endswith(".json"):
                 rename(path.join(wrong_dir,file),
                        path.join(settings_directory, file)) 
                 self.path = path.join(settings_directory, name + ".json")
-                
-        
+
+
         #If the owner of the settings directory is not the user, then set it as the user:
         if get_user_owner(settings_directory) != USER:
             chown(settings_directory, USER, USER)


### PR DESCRIPTION
With this, the files are copied automatically in the settings folder if present in the root directory (I'm scanning for file extension name (json), so if you will think to add json files to the root directory this will need to be changed) and copy them back to the settings folder. Permission issues on the settings folder are automatically fixed, both on creation and even if they are not matching after.

As far as my small tests are gone, it does seems to work perfectly fine now.

Let me know if I need to change anything else.

Marco