### PR TITLE
feat(MoreCustomizableToasts): Allow plugin developers to customize some toast properties

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     }
   },
   "dependencies": {
-    "decky-frontend-lib": "^3.7.14",
+    "decky-frontend-lib": "^3.14.0",
     "react-file-icon": "^1.2.0",
     "react-icons": "^4.4.0",
     "react-markdown": "^8.0.3",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -10,7 +10,7 @@ specifiers:
   '@types/react-file-icon': ^1.0.1
   '@types/react-router': 5.1.18
   '@types/webpack': ^5.28.0
-  decky-frontend-lib: ^3.7.14
+  decky-frontend-lib: ^3.14.0
   husky: ^8.0.1
   import-sort-style-module: ^6.0.0
   inquirer: ^8.2.4
@@ -30,7 +30,7 @@ specifiers:
   typescript: ^4.7.4
 
 dependencies:
-  decky-frontend-lib: 3.7.14
+  decky-frontend-lib: 3.14.0
   react-file-icon: 1.2.0_wcqkhtmu7mswc6yz4uyexck3ty
   react-icons: 4.4.0_react@16.14.0
   react-markdown: 8.0.3_vshvapmxg47tngu7tvrsqpq55u
@@ -944,8 +944,8 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /decky-frontend-lib/3.7.14:
-    resolution: {integrity: sha512-ShAoP3VqiwkJYukDBHsOF9fk7wYw0VaKpHw6j9WdzLxwZwBcg0J7QBNIFYP3nfA0UgEwSJVEg/22kONiplipmA==}
+  /decky-frontend-lib/3.14.0:
+    resolution: {integrity: sha512-cBGgS960ftGgpF/oDlRj02nISWq7rwKHIUzG7RJeHchLmz/M4W4OwDL2/oEYO+0WeSx/AWRHTIfLU27jdHiZYQ==}
     dev: false
 
   /decode-named-character-reference/1.0.2:

--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -129,16 +129,15 @@ class Toaster extends Logger {
     delete this.rNode.stateNode.shouldComponentUpdate;
 
     this.audioModule = findModuleChild((m: Module) => {
-      if (typeof m !== "object") return undefined;
+      if (typeof m !== 'object') return undefined;
       for (let prop in m) {
         try {
-          if (m[prop].PlayNavSound && m[prop].RegisterCallbackOnPlaySound)
-            return m[prop];
+          if (m[prop].PlayNavSound && m[prop].RegisterCallbackOnPlaySound) return m[prop];
         } catch {
-          return undefined
+          return undefined;
         }
       }
-    })
+    });
 
     this.log('Initialized');
     this.finishStartup?.();
@@ -163,7 +162,9 @@ class Toaster extends Logger {
     if (toast.showToast === undefined) toast.showToast = true;
     if (
       (window.settingsStore.settings.bDisableAllToasts && !toast.critical) ||
-      (window.settingsStore.settings.bDisableToastsInGame && !toast.critical && window.NotificationStore.BIsUserInGame())
+      (window.settingsStore.settings.bDisableToastsInGame &&
+        !toast.critical &&
+        window.NotificationStore.BIsUserInGame())
     )
       return;
     if (toast.playSound) this.audioModule?.PlayNavSound(toast.sound);

--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -7,6 +7,7 @@ import Logger from './logger';
 declare global {
   interface Window {
     __TOASTER_INSTANCE: any;
+    settingsStore: any;
     NotificationStore: any;
   }
 }
@@ -16,7 +17,6 @@ class Toaster extends Logger {
   // private toasterState: DeckyToasterState = new DeckyToasterState();
   private node: any;
   private rNode: any;
-  private settingsModule: any;
   private finishStartup?: () => void;
   private ready: Promise<void> = new Promise((res) => (this.finishStartup = res));
   private toasterPatch?: Patch;
@@ -135,7 +135,6 @@ class Toaster extends Logger {
     // toast.duration = toast.duration || 5e3;
     // this.toasterState.addToast(toast);
     await this.ready;
-    const settings = this.settingsModule?.settings;
     let toastData = {
       nNotificationID: window.NotificationStore.m_nNextTestNotificationID++,
       rtCreated: Date.now(),
@@ -147,8 +146,8 @@ class Toaster extends Logger {
     // @ts-ignore
     toastData.data.appid = () => 0;
     if (
-      (settings?.bDisableAllToasts && !toast.critical) ||
-      (settings?.bDisableToastsInGame && !toast.critical && window.NotificationStore.BIsUserInGame())
+      (window.settingsStore.settings.bDisableAllToasts && !toast.critical) ||
+      (window.settingsStore.settings.bDisableToastsInGame && !toast.critical && window.NotificationStore.BIsUserInGame())
     )
       return;
     window.NotificationStore.m_rgNotificationToasts.push(toastData);

--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -1,4 +1,4 @@
-import { Patch, ToastData, afterPatch, findInReactTree, sleep } from 'decky-frontend-lib';
+import { Module, Patch, ToastData, afterPatch, findInReactTree, findModuleChild, sleep } from 'decky-frontend-lib';
 import { ReactNode } from 'react';
 
 import Toast from './components/Toast';
@@ -17,6 +17,7 @@ class Toaster extends Logger {
   // private toasterState: DeckyToasterState = new DeckyToasterState();
   private node: any;
   private rNode: any;
+  private audioModule: any;
   private finishStartup?: () => void;
   private ready: Promise<void> = new Promise((res) => (this.finishStartup = res));
   private toasterPatch?: Patch;
@@ -127,6 +128,18 @@ class Toaster extends Logger {
     this.rNode.stateNode.forceUpdate();
     delete this.rNode.stateNode.shouldComponentUpdate;
 
+    this.audioModule = findModuleChild((m: Module) => {
+      if (typeof m !== "object") return undefined;
+      for (let prop in m) {
+        try {
+          if (m[prop].PlayNavSound && m[prop].RegisterCallbackOnPlaySound)
+            return m[prop];
+        } catch {
+          return undefined
+        }
+      }
+    })
+
     this.log('Initialized');
     this.finishStartup?.();
   }
@@ -138,20 +151,26 @@ class Toaster extends Logger {
     let toastData = {
       nNotificationID: window.NotificationStore.m_nNextTestNotificationID++,
       rtCreated: Date.now(),
-      eType: 15,
+      eType: toast.eType || 11,
       nToastDurationMS: toast.duration || (toast.duration = 5e3),
       data: toast,
       decky: true,
     };
     // @ts-ignore
     toastData.data.appid = () => 0;
+    if (toast.sound === undefined) toast.sound = 6;
+    if (toast.playSound === undefined) toast.playSound = true;
+    if (toast.showToast === undefined) toast.showToast = true;
     if (
       (window.settingsStore.settings.bDisableAllToasts && !toast.critical) ||
       (window.settingsStore.settings.bDisableToastsInGame && !toast.critical && window.NotificationStore.BIsUserInGame())
     )
       return;
-    window.NotificationStore.m_rgNotificationToasts.push(toastData);
-    window.NotificationStore.DispatchNextToast();
+    if (toast.playSound) this.audioModule?.PlayNavSound(toast.sound);
+    if (toast.showToast) {
+      window.NotificationStore.m_rgNotificationToasts.push(toastData);
+      window.NotificationStore.DispatchNextToast();
+    }
   }
 
   deinit() {


### PR DESCRIPTION
This PR does two main things:
- Replaced the settingsModule from Toaster with window.settingsStore because:
    - window.NotificationStore is already being used
    - from personal testing (SteamOS Preview, Decky-Loader Prerelease v2.4.4-pre1), decky-loader currently doesn't respect user-selected settings DisableAllToasts or DisableToastsInGame, and will send a toast when plugin updates are available
- Added properties matching those from SteamOS for `showToast`, `playSound`, `sound`, and `eType` to allow plugin developers the ability to have custom notification settings for their plugin (Toast+Sound, Toast only, Sound only, No notification)
    - showToast: boolean, shows a toast, defaults to true
    - playSound: boolean, plays sound, defaults to true
    - sound: number (0-25), audio sfx played when playSound is true, defaults to 6 (ToastMisc)
    - eType: number (1-24), type of toast, defaults to 11 as it seems to be closest in terms of properties to the current 15, but doesn't have a sfx tied to it

eType may be largely un-needed as the other three properties should cover most needs, but is included in-case another developer wants to explore some of the other toast types (of which many are somehow tied in with other features of SteamOS)

sound number to sfx mapping:
![image](https://user-images.githubusercontent.com/5753435/205269408-e9c66fac-e8a4-4f9c-bf96-3393857052e8.png)

## Depends on https://github.com/SteamDeckHomebrew/decky-frontend-lib/pull/64
