### PR TITLE
Add custom CDN support for custom stores

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,10 +47,10 @@ jobs:
       with:
         node-version: 18
       
-    - name: Set up Python 3.10.2 🐍
+    - name: Set up Python 3.10.9 🐍
       uses: actions/setup-python@v4
       with:
-        python-version: "3.10.2"
+        python-version: "3.10.9"
         
     - name: Install Python dependencies ⬇️
       run: |

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -10,6 +10,7 @@ export enum Store {
 export interface StorePluginVersion {
   name: string;
   hash: string;
+  artifact: string | undefined | null;
 }
 
 export interface StorePlugin {
@@ -73,9 +74,11 @@ export async function installFromURL(url: string) {
 }
 
 export async function requestPluginInstall(plugin: string, selectedVer: StorePluginVersion) {
+  const artifactUrl =
+    selectedVer.artifact ?? `https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/versions/${selectedVer.hash}.zip`;
   await window.DeckyPluginLoader.callServerMethod('install_plugin', {
     name: plugin,
-    artifact: `https://cdn.tzatzikiweeb.moe/file/steam-deck-homebrew/versions/${selectedVer.hash}.zip`,
+    artifact: artifactUrl,
     version: selectedVer.name,
     hash: selectedVer.hash,
   });


### PR DESCRIPTION
Currently, custom stores are supported but the main CDN is always used. This prevents independent custom stores from existing.

This adds support for a providing a custom artifact url for every plugin version in the store. When that field is not provided (or null), it falls back to the main store's CDN.