### PR TITLE
allow hand-sorting plugins

### DIFF
--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -9,13 +9,15 @@ import {
 } from 'decky-frontend-lib';
 import { VFC } from 'react';
 
+import { useOrderedPlugins } from '../utils/hooks/useOrderedPlugins';
 import { useDeckyState } from './DeckyState';
 import NotificationBadge from './NotificationBadge';
 import { useQuickAccessVisible } from './QuickAccessVisibleState';
 import TitleView from './TitleView';
 
 const PluginView: VFC = () => {
-  const { plugins, updates, activePlugin, setActivePlugin, closeActivePlugin } = useDeckyState();
+  const { updates, activePlugin, setActivePlugin, closeActivePlugin } = useDeckyState();
+  const { orderedPlugins } = useOrderedPlugins();
   const visible = useQuickAccessVisible();
 
   if (activePlugin) {
@@ -36,7 +38,7 @@ const PluginView: VFC = () => {
       <TitleView />
       <div className={joinClassNames(staticClasses.TabGroupPanel, scrollClasses.ScrollPanel, scrollClasses.ScrollY)}>
         <PanelSection>
-          {plugins
+          {orderedPlugins
             .filter((p) => p.content)
             .map(({ name, icon }) => (
               <PanelSectionRow key={name}>

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -3,16 +3,18 @@ import { useEffect } from 'react';
 import { FaDownload, FaEllipsisH } from 'react-icons/fa';
 
 import { requestPluginInstall } from '../../../../store';
+import { useOrderedPlugins } from '../../../../utils/hooks/useOrderedPlugins';
 import { useDeckyState } from '../../../DeckyState';
 
 export default function PluginList() {
-  const { plugins, updates } = useDeckyState();
+  const { updates } = useDeckyState();
+  const { orderedPlugins, movePlugin } = useOrderedPlugins();
 
   useEffect(() => {
     window.DeckyPluginLoader.checkPluginUpdates();
   }, []);
 
-  if (plugins.length === 0) {
+  if (orderedPlugins.length === 0) {
     return (
       <div>
         <p>No plugins installed</p>
@@ -22,7 +24,7 @@ export default function PluginList() {
 
   return (
     <ul style={{ listStyleType: 'none' }}>
-      {plugins.map(({ name, version }) => {
+      {orderedPlugins.map(({ name, version }, index) => {
         const update = updates?.get(name);
         return (
           <li style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', paddingBottom: '10px' }}>
@@ -48,6 +50,24 @@ export default function PluginList() {
                     <Menu label="Plugin Actions">
                       <MenuItem onSelected={() => window.DeckyPluginLoader.importPlugin(name, version)}>
                         Reload
+                      </MenuItem>
+                      <MenuItem disabled={index == 0} onSelected={() => movePlugin(name, 'top')}>
+                        Move To Top
+                      </MenuItem>
+                      <MenuItem disabled={index == 0} onSelected={() => movePlugin(name, 'up')}>
+                        Move Up
+                      </MenuItem>
+                      <MenuItem
+                        disabled={index == orderedPlugins.length - 1}
+                        onSelected={() => movePlugin(name, 'down')}
+                      >
+                        Move Down
+                      </MenuItem>
+                      <MenuItem
+                        disabled={index == orderedPlugins.length - 1}
+                        onSelected={() => movePlugin(name, 'bottom')}
+                      >
+                        Move To Bottom
                       </MenuItem>
                       <MenuItem onSelected={() => window.DeckyPluginLoader.uninstallPlugin(name)}>Uninstall</MenuItem>
                     </Menu>,

--- a/frontend/src/utils/hooks/useOrderedPlugins.tsx
+++ b/frontend/src/utils/hooks/useOrderedPlugins.tsx
@@ -1,0 +1,45 @@
+import { useMemo } from 'react';
+
+import { useDeckyState } from '../../components/DeckyState';
+import { useSetting } from './useSetting';
+
+export function useOrderedPlugins() {
+  const { plugins } = useDeckyState();
+  const [pluginOrder, setPluginOrder] = useSetting<string[]>('plugin-order', []);
+  const orderedPlugins = useMemo(() => {
+    let pluginIndexes = Object.fromEntries(pluginOrder.map((pluginName, index) => [pluginName, index] as const));
+    return plugins.concat().sort((a, b) => {
+      if (a.name in pluginIndexes && b.name in pluginIndexes) return pluginIndexes[a.name] - pluginIndexes[b.name];
+      if (a.name in pluginIndexes) return -1;
+      if (b.name in pluginIndexes) return 1;
+      return 0;
+    });
+  }, [pluginOrder, plugins]);
+
+  return {
+    orderedPlugins,
+    movePlugin,
+  };
+
+  function movePlugin(pluginName: string, target: 'up' | 'top' | 'down' | 'bottom') {
+    // get the current plugin order - this includes
+    // all plugins that previously did not have a sort order
+    // and removed all plugins that have been uninstalled
+    const currentPluginOrder = orderedPlugins.map((plugin) => plugin.name);
+    const index = currentPluginOrder.indexOf(pluginName);
+    if (index == -1) return;
+    // remove the plugin
+    currentPluginOrder.splice(index, 1);
+    // reinsert at new position
+    const newPosition =
+      target == 'top'
+        ? 0
+        : target == 'up'
+        ? Math.max(index - 1, 0)
+        : target == 'down'
+        ? Math.min(index + 1, currentPluginOrder.length)
+        : currentPluginOrder.length;
+    currentPluginOrder.splice(newPosition, 0, pluginName);
+    setPluginOrder(currentPluginOrder);
+  }
+}

--- a/frontend/src/utils/hooks/useSetting.ts
+++ b/frontend/src/utils/hooks/useSetting.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 
 import { getSetting, setSetting } from '../settings';
 
+const settingUpdates = new EventTarget();
+
 export function useSetting<T>(key: string, def: T): [value: T, setValue: (value: T) => Promise<void>] {
   const [value, setValue] = useState(def);
 
@@ -12,11 +14,22 @@ export function useSetting<T>(key: string, def: T): [value: T, setValue: (value:
     })();
   }, []);
 
+  useEffect(() => {
+    function listener(event: Event) {
+      if (event instanceof CustomEvent) {
+        setValue(event.detail);
+      }
+    }
+    settingUpdates.addEventListener(key, listener);
+    return () => settingUpdates.removeEventListener(key, listener);
+  });
+
   return [
     value,
     async (val: T) => {
       setValue(val);
       await setSetting(key, val);
+      settingUpdates.dispatchEvent(new CustomEvent(key, { detail: val }));
     },
   ];
 }


### PR DESCRIPTION
This would solve #226.

As I was almost done with that, @Tormak9970 mentioned that they had their own implementation to list sorting, so maybe that might be preferrable over this - but either way, maybe some other code from this PR might be salvageable :)

[Screenshot of the orderable list by Tormak9970](https://github.com/Tormak9970/portfolio-site-v2/blob/main/public/img/projs/Bash%20Shortcuts%20-%20Manage%20View.png)

[Screenshot of my solution](https://steamcommunity.com/sharedfiles/filedetails/?id=2900472013)

I went for the approach of having a sorted array of plugin names and keeping that in a setting.  
This required me to add an `EventTarget` to the `useSettings` hook so that updating a setting in one screen will synchronize to all other screens. Granted, this could also be done with an additional Context, but seems to work very nicely and imitates a pattern that is already used elsewhere in Decky.