### PR TITLE
Add cef debugging to the installer scripts

### DIFF
--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -11,6 +11,7 @@ HOMEBREW_FOLDER="${USER_DIR}/homebrew"
 rm -rf "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/plugins"
+touch "${USER_DIR}/.steam/steam/.cef-enable-remote-debugging"
 
 # Download latest release and install it
 RELEASE=$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "true"))")

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -11,6 +11,7 @@ HOMEBREW_FOLDER="${USER_DIR}/homebrew"
 rm -rf "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/services"
 sudo -u $SUDO_USER mkdir -p "${HOMEBREW_FOLDER}/plugins"
+touch "${USER_DIR}/.steam/steam/.cef-enable-remote-debugging"
 
 # Download latest release and install it
 RELEASE=$(curl -s 'https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases' | jq -r "first(.[] | select(.prerelease == "false"))")


### PR DESCRIPTION
Adds automatic enabling of cef debugging in the (soon to be old) installers.
Works fine on my deck.

Might be worth adding an `echo "Enabling CEF debugging"` to the file to alert the user, but probably not.