### PR TITLE
Add feature requests as an issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,6 +27,9 @@ body:
       label: Further Description
       description: A further explanation of the feature. If appropriate, include screenshots or videos.
       placeholder: |
-        Decky plugins should be sortable in the quick access menu
+        This would help make the UI clearer and easier to use as there is less clutter in the QAM.
+        It would also make it faster to access plugins that are used more.
+
+        This could be implemented by adding ...
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature request
+description: Request a new feature (NOT A PLUGIN)
+title: "[Request] <title>"
+labels: [feature request]
+body:
+  - type: checkboxes
+    id: low-effort-checks
+    attributes:
+      label: Please confirm
+      description: Issues without all checks may be ignored/closed.
+      options:
+        - label: I have searched existing issues
+        - label: This issue is not a duplicate of an existing one
+        - label: This is not a request for a plugin
+
+  - type: textarea
+    attributes:
+      label: Feature Request Description
+      description: A clear and concise description of what the new feature. 
+      placeholder: |
+        Decky plugins should be sortable in the quick access menu
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Further Description
+      description: A further explanation of the feature. If appropriate, include screenshots or videos.
+      placeholder: |
+        Decky plugins should be sortable in the quick access menu
+    validations:
+      required: false


### PR DESCRIPTION
adds feature requests as another issue type. 
(if you don't want to merge this, then `.github/ISSUE_TEMPLATE/config.yml` should probably have `blank_issues_enabled` re-enabled or feature requests will have to fit within the bug request template which is annoying)

![image](https://user-images.githubusercontent.com/48649272/211062765-3122f254-469b-4381-a273-fa99d82df5bf.png)

----
![image](https://user-images.githubusercontent.com/48649272/211062806-38cbbbd4-b3bc-41cb-9e2d-1d98f56c471b.png)