### PR TITLE
disable CEF debugging on uninstall

### DIFF
--- a/dist/uninstall.sh
+++ b/dist/uninstall.sh
@@ -18,3 +18,5 @@ rm -rf "/tmp/plugin_loader"
 # Cleanup services folder
 sudo rm "${HOMEBREW_FOLDER}/services/PluginLoader"
 
+# Disable CEF debugging
+sudo rm "${USER_DIR}/.steam/steam/.cef-enable-remote-debugging"


### PR DESCRIPTION
CEF debugging is automatically enabled for the user, and it's possible they don't even know it's active.
This is fine while Decky is installed, as it isn't forwarded to the network. 
However, when Decky is uninstalled, it will be forwarded to the network which could be a pretty major security flaw.

This _would_ break crankshaft for users of both plugin loaders but crankshaft doesn't work at all right now and it doesn't work with decky and they could just re-enable it so I think it's not a big deal.