### PR TITLE
Inject only in gamepad ui mode

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -172,7 +172,7 @@ class PluginManager:
             if first:
                 if await tab.has_global_var("deckyHasLoaded", False):
                     await close_old_tabs()
-            await tab.evaluate_js("try{if (window.deckyHasLoaded){setTimeout(() => location.reload(), 100)}else{window.deckyHasLoaded = true;(async()=>{try{while(!window.SP_REACT){await new Promise(r => setTimeout(r, 10))};await import('http://localhost:1337/frontend/index.js')}catch(e){console.error(e)};})();}}catch(e){console.error(e)}", False, False, False)
+            await tab.evaluate_js("try{if (window.deckyHasLoaded){setTimeout(() => location.reload(), 100)}else{window.deckyHasLoaded = true;(async()=>{try{while(!window.SP_REACT){await new Promise(r => setTimeout(r, 10))};if (!window?.SteamClient?.UI?.GetUIMode || (await window.SteamClient.UI.GetUIMode()) === 4) await import('http://localhost:1337/frontend/index.js')}catch(e){console.error(e)};})();}}catch(e){console.error(e)}", False, False, False)
         except:
             logger.info("Failed to inject JavaScript into tab\n" + format_exc())
             pass


### PR DESCRIPTION
Additional safeguard using 'SteamClient.UI.GetUIMode()' to only inject decky in gamepad ui mode (or gaming mode). Injecting decky into the desktop mode Steam client could lead to unintended behaviour.

Some users using plugins like AudioLoader have reported that they would seemingly be active even with the desktop mode Steam client. Plugin developers usually don't account for that possibility and it could lead to strange and unintended behaviour.

`SteamClient.UI.GetUIMode()` seems to do the trick to determine in which UI mode Steam is running. It returns `0` for desktop mode Steam Client and `4` for gamepad ui mode Steam Client.

I'm having trouble reproducing the issue on my end unfortunately, decky does not even manage to inject itself into the Steam Client for me. I've tested the inverted condition though with `(await window.SteamClient.UI.GetUIMode()) !== 4)` and it successfully prevents decky from injecting itself in gamepad ui mode.
The themes from CSSLoader still seem to get injected though, so there might be some more logic needed to completely prevent CSS injection too but it might not be needed if the execution of the plugin code itself is avoided.