### PR TITLE
Fix http_request and fetchNoCors methods erroring when including a body.

### DIFF
--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -335,6 +335,7 @@ class PluginLoader extends Logger {
       fetchNoCors(url: string, request: any = {}) {
         let args = { method: 'POST', headers: {} };
         const req = { ...args, ...request, url, data: request.body };
+        req?.body && delete req.body
         return this.callServerMethod('http_request', req);
       },
       executeInTab(tab: string, runAsync: boolean, code: string) {


### PR DESCRIPTION
The http_request method requires the `body` attribute to be named `data`, the method renames the input's body to data to make it work, however it doesn't delete the original body property, so http_request errors out if you attempt to include a body. This just deleted the body property after it's been renamed to data.


Has been built and tested using a function akin to the following, and everything now works.
```
fetchNoCors(`https://example.com`, {
        method: "POST",
        headers: { "Content-Type": "application/json" },
        body: JSON.stringify({ message: "Example Message" }),
})
```