### PR TITLE
Add support for more hardware when building

### DIFF
--- a/act/run-act.sh
+++ b/act/run-act.sh
@@ -26,10 +26,10 @@ cd ..
 
 if [[ "$type" == "release" ]]; then
     printf "release!\n"
-    act workflow_dispatch -e act/release.json --artifact-server-path act/artifacts
+    act workflow_dispatch -e act/release.json --artifact-server-path act/artifacts --container-architecture linux/amd64
 elif [[ "$type" == "prerelease" ]]; then
     printf "prerelease!\n"
-    act workflow_dispatch -e act/prerelease.json --artifact-server-path act/artifacts
+    act workflow_dispatch -e act/prerelease.json --artifact-server-path act/artifacts --container-architecture linux/amd64
 else
     printf "Release type unspecified/badly specified.\n"
     printf "Options: 'release' or 'prerelease'\n"


### PR DESCRIPTION
By specifying the `linux/amd64` Docker container architecture, hardware that doesn't use `amd64` (ex. Apple silicon processors) is able to build Decky Loader artifacts using the `act/run-act.sh` script.

Please feel free to test with and without the provided changes and report the changes across different systems.