### PR TITLE
Fix fullscreen route inject issues caused by Feb. 17th beta.

### DIFF
--- a/frontend/src/router-hook.tsx
+++ b/frontend/src/router-hook.tsx
@@ -123,14 +123,9 @@ class RouterHook extends Logger {
     this.wrapperPatch = afterPatch(this.gamepadWrapper, 'render', (_: any, ret: any) => {
       if (ret?.props?.children?.props?.children?.length == 5 || ret?.props?.children?.props?.children?.length == 4) {
         const idx = ret?.props?.children?.props?.children?.length == 4 ? 1 : 2;
-        if (
-          ret.props.children.props.children[idx]?.props?.children?.[0]?.type?.type
-            ?.toString()
-            ?.includes('GamepadUI.Settings.Root()') ||
-          ret.props.children.props.children[idx]?.props?.children?.[0]?.type?.type
-            ?.toString()
-            ?.includes('Settings.Root()')
-        ) {
+        const potentialSettingsRootString =
+          ret.props.children.props.children[idx]?.props?.children?.[0]?.type?.type?.toString() || '';
+        if (potentialSettingsRootString?.includes('Settings.Root()')) {
           if (!this.router) {
             this.router = ret.props.children.props.children[idx]?.props?.children?.[0]?.type;
             this.routerPatch = afterPatch(this.router, 'type', (_: any, ret: any) => {

--- a/frontend/src/router-hook.tsx
+++ b/frontend/src/router-hook.tsx
@@ -126,7 +126,10 @@ class RouterHook extends Logger {
         if (
           ret.props.children.props.children[idx]?.props?.children?.[0]?.type?.type
             ?.toString()
-            ?.includes('GamepadUI.Settings.Root()')
+            ?.includes('GamepadUI.Settings.Root()') ||
+          ret.props.children.props.children[idx]?.props?.children?.[0]?.type?.type
+            ?.toString()
+            ?.includes('Settings.Root()')
         ) {
           if (!this.router) {
             this.router = ret.props.children.props.children[idx]?.props?.children?.[0]?.type;


### PR DESCRIPTION
The newest beta renamed `GamepadUI.Settings.Root()` to `Settings.Root()` the component which decky attempts to inject into.

This fix searches for `Settings.Root()`, which would be a part of `GamepadUI.Settings.Root()`, meaning that it doesn't break anything for people who haven't updated yet.