### PR TITLE
Remove commented-out unused imports

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -1,7 +1,5 @@
 # Full imports
 import json
-# import pprint
-# from pprint import pformat
 
 # Partial imports
 from aiohttp import ClientSession, web


### PR DESCRIPTION
Removed several lines of commented-out import statements that were not being used in the codebase. These imports were likely left behind from earlier development work and were no longer needed. The removal of these unused imports will help to improve code readability and maintainability going forward