### PR TITLE
Fix QAM And Toaster Injection for Mar 02 Beta

### DIFF
--- a/backend/updater.py
+++ b/backend/updater.py
@@ -108,10 +108,10 @@ class Updater:
         logger.debug("determining release type to find, branch is %i" % selectedBranch)
         if selectedBranch == 0:
             logger.debug("release type: release")
-            self.remoteVer = next(filter(lambda ver: ver["tag_name"].startswith("v") and not ver["prerelease"] and ver["tag_name"], remoteVersions), None)
+            self.remoteVer = next(filter(lambda ver: ver["tag_name"].startswith("v") and not ver["prerelease"] and not ver["tag_name"].find("-pre") > 0 and ver["tag_name"], remoteVersions), None)
         elif selectedBranch == 1:
             logger.debug("release type: pre-release")
-            self.remoteVer = next(filter(lambda ver: ver["prerelease"] and ver["tag_name"].startswith("v") and ver["tag_name"].find("-pre"), remoteVersions), None)
+            self.remoteVer = next(filter(lambda ver:ver["tag_name"].startswith("v"), remoteVersions), None)
         else:
             logger.error("release type: NOT FOUND")
             raise ValueError("no valid branch found")

--- a/frontend/src/tabs-hook.tsx
+++ b/frontend/src/tabs-hook.tsx
@@ -35,7 +35,7 @@ class TabsHook extends Logger {
     const tree = (document.getElementById('root') as any)._reactRootContainer._internalRoot.current;
     let qAMRoot: any;
     const findQAMRoot = (currentNode: any, iters: number): any => {
-      if (iters >= 55) {
+      if (iters >= 65) {
         // currently 45
         return null;
       }

--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -45,6 +45,7 @@ class Toaster extends Logger {
         return null;
       }
       if (
+        currentNode?.memoizedProps?.className?.startsWith?.('gamepadtoasts_GamepadToastPlaceholder') ||
         currentNode?.memoizedProps?.className?.startsWith?.('toastmanager_ToastPlaceholder') ||
         currentNode?.memoizedProps?.className?.startsWith?.('toastmanager_ToastPopup')
       ) {


### PR DESCRIPTION
This also implements @TrainDoctor 's patch for having the newest stable release also show in pre-release channel.

The fix for the QAM injection was simply to up the iteration count from 55 to 65
For the toaster, Valve had renamed it from `toastmanager_ToastPlaceholder` to `gamepadtoasts_GamepadToastPlaceholder`