### PR TITLE
Expose USER_ID and DECKY_USER_ID to plugins

### DIFF
--- a/backend/plugin.py
+++ b/backend/plugin.py
@@ -64,8 +64,10 @@ class PluginWrapper:
             # export a bunch of environment variables to help plugin developers
             environ["HOME"] = helpers.get_home_path("root" if "root" in self.flags else helpers.get_user())
             environ["USER"] = "root" if "root" in self.flags else helpers.get_user()
+            environ["USER_ID"] = "0" if "root" in self.flags else helpers.get_user_id()
             environ["DECKY_VERSION"] = helpers.get_loader_version()
             environ["DECKY_USER"] = helpers.get_user()
+            environ["DECKY_USER_ID"] = helpers.get_user_id()
             environ["DECKY_USER_HOME"] = helpers.get_home_path()
             environ["DECKY_HOME"] = helpers.get_homebrew_path()
             environ["DECKY_PLUGIN_SETTINGS_DIR"] = path.join(environ["DECKY_HOME"], "settings", self.plugin_directory)

--- a/plugin/decky_plugin.py
+++ b/plugin/decky_plugin.py
@@ -38,6 +38,14 @@ It would be `root` if `root` was specified in the plugin's flags otherwise the u
 e.g.: `deck`
 """
 
+USER_ID: int = int(os.getenv("USER_ID", default="-1"))
+"""
+The effective UID running the process.
+Environment variable: `USER_ID`.
+It would be `0` if `root` was specified in the plugin's flags otherwise the id of the user whose home decky resides in.
+e.g.: `1000`
+"""
+
 DECKY_VERSION: str = os.getenv("DECKY_VERSION", default="")
 """
 The version of the decky loader.
@@ -50,6 +58,13 @@ DECKY_USER: str = os.getenv("DECKY_USER", default="")
 The user whose home decky resides in.
 Environment variable: `DECKY_USER`.
 e.g.: `deck`
+"""
+
+DECKY_USER_ID: int = int(os.getenv("DECKY_USER_ID", default="-1"))
+"""
+The UID of the user whose home decky resides in.
+Environment variable: `DECKY_USER_ID`.
+e.g.: `1000`
 """
 
 DECKY_USER_HOME: str = os.getenv("DECKY_USER_HOME", default="")

--- a/plugin/decky_plugin.pyi
+++ b/plugin/decky_plugin.pyi
@@ -36,6 +36,14 @@ It would be `root` if `root` was specified in the plugin's flags otherwise the u
 e.g.: `deck`
 """
 
+USER_ID: int
+"""
+The effective UID running the process.
+Environment variable: `UID`.
+It would be `0` if `root` was specified in the plugin's flags otherwise the id of the user whose home decky resides in.
+e.g.: `1000`
+"""
+
 DECKY_VERSION: str
 """
 The version of the decky loader.
@@ -48,6 +56,13 @@ DECKY_USER: str
 The user whose home decky resides in.
 Environment variable: `DECKY_USER`.
 e.g.: `deck`
+"""
+
+DECKY_USER_ID: int
+"""
+The UID of the user whose home decky resides in.
+Environment variable: `DECKY_USER_ID`.
+e.g.: `1000`
 """
 
 DECKY_USER_HOME: str


### PR DESCRIPTION
A situation came up in [my plugin](https://github.com/jvyden/deck-kdeconnect/blob/main/main.py#L7-L22) where I needed to get the user's id, and saw no variable in `decky_plugin` for it, so I added it using existing APIs.

Normally this should be `1000` but it can technically be different, so here we are.

*P.S.: This is unfortunately untested due to complications regarding getting Decky running locally, so it would be appreciated if someone could give this a proper test :pray:*