### PR TITLE
fix #390 the plugin_directory argument to import_plugin was incorrect

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -42,7 +42,7 @@ class PluginBrowser:
             return False
         zip_file = ZipFile(zip)
         zip_file.extractall(self.plugin_path)
-        plugin_dir = self.find_plugin_folder(name)
+        plugin_dir = path.join(self.plugin_path, self.find_plugin_folder(name))
         code_chown = call(["chown", "-R", get_user()+":"+get_user_group(), plugin_dir])
         code_chmod = call(["chmod", "-R", "555", plugin_dir])
         if code_chown != 0 or code_chmod != 0:
@@ -92,6 +92,7 @@ class PluginBrowser:
 
         return rv
 
+    """Return the filename (only) for the specified plugin"""
     def find_plugin_folder(self, name):
         for folder in listdir(self.plugin_path):
             try:
@@ -99,7 +100,7 @@ class PluginBrowser:
                     plugin = json.load(f)
 
                 if plugin['name'] == name:
-                    return str(path.join(self.plugin_path, folder))
+                    return folder
             except:
                 logger.debug(f"skipping {folder}")
 
@@ -107,9 +108,10 @@ class PluginBrowser:
         if self.loader.watcher:
             self.loader.watcher.disabled = True
         tab = await get_gamepadui_tab()
+        plugin_dir = path.join(self.plugin_path, self.find_plugin_folder(name))
         try:
             logger.info("uninstalling " + name)
-            logger.info(" at dir " + self.find_plugin_folder(name))
+            logger.info(" at dir " + plugin_dir)
             logger.debug("calling frontend unload for %s" % str(name))
             res = await tab.evaluate_js(f"DeckyPluginLoader.unloadPlugin('{name}')")
             logger.debug("result of unload from UI: %s", res)
@@ -123,11 +125,11 @@ class PluginBrowser:
                 del self.plugins[name]
                 logger.debug("Plugin %s was removed from the dictionary", name)
             logger.debug("removing files %s" % str(name))
-            rmtree(self.find_plugin_folder(name))
+            rmtree(plugin_dir)
         except FileNotFoundError:
             logger.warning(f"Plugin {name} not installed, skipping uninstallation")
         except Exception as e:
-            logger.error(f"Plugin {name} in {self.find_plugin_folder(name)} was not uninstalled")
+            logger.error(f"Plugin {name} in {plugin_dir} was not uninstalled")
             logger.error(f"Error at %s", exc_info=e)
         if self.loader.watcher:
             self.loader.watcher.disabled = False
@@ -160,7 +162,8 @@ class PluginBrowser:
                 logger.debug("Unzipping...")
                 ret = self._unzip_to_plugin_dir(res_zip, name, hash)
                 if ret:
-                    plugin_dir = self.find_plugin_folder(name)
+                    plugin_folder = self.find_plugin_folder(name)
+                    plugin_dir = path.join(self.plugin_path, plugin_folder)
                     ret = await self._download_remote_binaries_for_plugin_with_name(plugin_dir)
                     if ret:
                         logger.info(f"Installed {name} (Version: {version})")
@@ -168,7 +171,7 @@ class PluginBrowser:
                             self.loader.plugins[name].stop()
                             self.loader.plugins.pop(name, None)
                         await sleep(1)
-                        self.loader.import_plugin(path.join(plugin_dir, "main.py"), name)
+                        self.loader.import_plugin(path.join(plugin_dir, "main.py"), plugin_folder)
                     else:
                         logger.fatal(f"Failed Downloading Remote Binaries")
                 else:

--- a/backend/browser.py
+++ b/backend/browser.py
@@ -168,7 +168,7 @@ class PluginBrowser:
                             self.loader.plugins[name].stop()
                             self.loader.plugins.pop(name, None)
                         await sleep(1)
-                        self.loader.import_plugin(path.join(plugin_dir, "main.py"), plugin_dir)
+                        self.loader.import_plugin(path.join(plugin_dir, "main.py"), name)
                     else:
                         logger.fatal(f"Failed Downloading Remote Binaries")
                 else:


### PR DESCRIPTION
While investigating this bug it quickly became apparent (after adding some debug prints) that key environ vars (such as DECKY_PLUGIN_LOG_DIR) had the wrong values.  This was an indirect result of how those values were built. Example here from LOG_DIR:

environ["DECKY_PLUGIN_LOG_DIR"] = path.join(environ["DECKY_HOME"], "logs", self.plugin_directory)

Note the last parameter to path.join is the self.plugin_directory.  But it is important to notice (though it might have once been a full directory path) all other users of this code are actually passing in just the plugin name for this parameter.  And if we incorrectly pass in a full abs path (such as /home/deck/homebrew/dev/plugins in this case) - any abspath is guaranteed to completely replace all prior arguments to path.join.

Note - this bug occurs in the 2.6.2 released version of the plugin loader - not just while running under dev.  Without this fix or similar I suspect all newly installed plugins are not having their python code started until the next steam deck reboot (where import_plugin is invoked correctly). (reviewers see comments in that issue)

See #390 for logs indicating the problem.