### PR TITLE
Various readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ For more information about Decky Loader as well as documentation and development
 
 - Syncthing may use port 8080 on Steam Deck, which Decky Loader needs to function. If you are using Syncthing as a service, please change its port to something else.
 - If you are using any software that uses port 1337 or 8080, please change its port to something else or uninstall it.
-- Sometimes Decky will disappear on SteamOS updates. This can easily be fixed by just re-running the installer and installing the stable branch again. If this doesn't work, try installing the prerelease instead. If that doesn't work, then [check the existing issues](https://github.com/PartyWumpus/decky-loader/issues) and if there isn't one then you can [file a new issue](https://github.com/PartyWumpus/decky-loader/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Ctitle%3E).
+- Sometimes Decky will disappear on SteamOS updates. This can easily be fixed by just re-running the installer and installing the stable branch again. If this doesn't work, try installing the prerelease instead. If that doesn't work, then [check the existing issues](https://github.com/SteamDeckHomebrew/decky-loader/issues) and if there isn't one then you can [file a new issue](https://github.com/SteamDeckHomebrew/decky-loader/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Ctitle%3E).
 
 ## 💾 Installation
 - This installation can be done without an admin/sudo password set.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ For more information about Decky Loader as well as documentation and development
 
 ### 🤔 Common Issues
 
-- Crankshaft is incompatible with Decky Loader. If you are using Crankshaft, please uninstall it before installing Decky Loader.
 - Syncthing may use port 8080 on Steam Deck, which Decky Loader needs to function. If you are using Syncthing as a service, please change its port to something else.
 - If you are using any software that uses port 1337 or 8080, please change its port to something else or uninstall it.
 - Sometimes Decky will disappear on SteamOS updates. This can easily be fixed by just re-running the installer and installing the stable branch again. If this doesn't work, try installing the prerelease instead. If that doesn't work, then [check the existing issues](https://github.com/PartyWumpus/decky-loader/issues) and if there isn't one then you can [file a new issue](https://github.com/PartyWumpus/decky-loader/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Ctitle%3E).

--- a/README.md
+++ b/README.md
@@ -48,14 +48,14 @@ For more information about Decky Loader as well as documentation and development
 1. Press the <img src="./docs/images/light/steam.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/steam.svg#gh-light-mode-only" height=16> button and open the Power menu.
 1. Select "Switch to Desktop".
 1. Navigate to this Github page on a browser of your choice.
-1. Press the 'Download' button at the top of the page.
-1. Run the downloaded file by clicking on it in Dolphin (the file manager).
-1. Either type your admin password or allow Decky to temporarily set your password to `Decky!`
+1. Download the [installer file](https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/decky_installer.desktop)
+1. Drag the file onto your desktop and double click it to run it.
+1. Either type your admin password or allow Decky to temporarily set your password to `Decky!` (this will be removed after the installer finishes)
 1. Choose the version of Decky Loader you want to install.
    - **Latest Release**  
      Intended for most users. This is the latest stable version of Decky Loader.  
    - **Latest Pre-Release**  
-     Intended for plugin developers. Pre-releases are unlikely to be fully stable but contain the latest changes. For more information on plugin development, please consult [the wiki page](https://deckbrew.xyz/en/loader-dev/development).
+     Intended for plugin developers. Pre-releases are unlikely to be fully stable but contain the latest changes. For more information on plugin development, please consult [the wiki page](https://wiki.deckbrew.xyz/en/loader-dev/development).
 1. Open the Return to Gaming Mode shortcut on your desktop.
 
 - There is also a fast install for those who can use Konsole. Run `curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh` and type your password when prompted.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ For more information about Decky Loader as well as documentation and development
 1. Press the <img src="./docs/images/light/steam.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/steam.svg#gh-light-mode-only" height=16> button and open the Power menu.
 1. Select "Switch to Desktop".
 1. Navigate to this Github page on a browser of your choice.
-1. Download the [installer file](https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/decky_installer.desktop)
+1. Download the [installer file](https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/decky_installer.desktop).
 1. Drag the file onto your desktop and double click it to run it.
 1. Either type your admin password or allow Decky to temporarily set your admin password to `Decky!` (this password will be removed after the installer finishes)
 1. Choose the version of Decky Loader you want to install.
@@ -65,7 +65,7 @@ We are sorry to see you go! If you are considering uninstalling because you are 
 
 1. Press the <img src="./docs/images/light/steam.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/steam.svg#gh-light-mode-only" height=16> button and open the Power menu.
 1. Select "Switch to Desktop".
-1. Run the installer file again, and select `uninstall decky loader` 
+1. Run the installer file again, and select `uninstall decky loader`.
 - There is also a fast uninstall for those who can use Konsole. Run `curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/uninstall.sh | sh` and type your password when prompted.
 
 ## 🚀 Getting Started

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For more information about Decky Loader as well as documentation and development
 1. Navigate to this Github page on a browser of your choice.
 1. Download the [installer file](https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/decky_installer.desktop)
 1. Drag the file onto your desktop and double click it to run it.
-1. Either type your admin password or allow Decky to temporarily set your password to `Decky!` (this will be removed after the installer finishes)
+1. Either type your admin password or allow Decky to temporarily set your admin password to `Decky!` (this password will be removed after the installer finishes)
 1. Choose the version of Decky Loader you want to install.
    - **Latest Release**  
      Intended for most users. This is the latest stable version of Decky Loader.  

--- a/README.md
+++ b/README.md
@@ -36,13 +36,12 @@ For more information about Decky Loader as well as documentation and development
 - Crankshaft is incompatible with Decky Loader. If you are using Crankshaft, please uninstall it before installing Decky Loader.
 - Syncthing may use port 8080 on Steam Deck, which Decky Loader needs to function. If you are using Syncthing as a service, please change its port to something else.
 - If you are using any software that uses port 1337 or 8080, please change its port to something else or uninstall it.
-- If you run the installer and it just opens a file in a text editor: click the (...) button in the top right of dolphin (the file manager) then 'configure' and 'configure dolphin'. Click on the 'confirmations' tab and set 'when opening an executable file' to 'run script'.
 
 ## 💾 Installation
 - This installation can be done without an admin/sudo password set.
 1. Prepare a mouse and keyboard if possible.
    - Keyboards and mice can be connected to the Steam Deck via USB-C or Bluetooth.
-   - Many Bluetooth keyboard and mouse apps are available for iOS and Android.
+   - Many Bluetooth keyboard and mouse apps are available for iOS and Android. (KDE connect is preinstalled on the steam deck)
    - The Steam Link app is available on [Windows](https://media.steampowered.com/steamlink/windows/latest/SteamLink.zip), [macOS](https://apps.apple.com/us/app/steam-link/id1246969117), and [Linux](https://flathub.org/apps/details/com.valvesoftware.SteamLink). It works well as a remote desktop substitute.
    - If you have no other options, use the right trackpad as a mouse and press <img src="./docs/images/light/steam.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/steam.svg#gh-light-mode-only" height=16>+<img src="./docs/images/light/x.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/x.svg#gh-light-mode-only" height=16> to open the on-screen keyboard as needed.
 1. Press the <img src="./docs/images/light/steam.svg#gh-dark-mode-only" height=16><img src="./docs/images/dark/steam.svg#gh-light-mode-only" height=16> button and open the Power menu.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ For more information about Decky Loader as well as documentation and development
 - Crankshaft is incompatible with Decky Loader. If you are using Crankshaft, please uninstall it before installing Decky Loader.
 - Syncthing may use port 8080 on Steam Deck, which Decky Loader needs to function. If you are using Syncthing as a service, please change its port to something else.
 - If you are using any software that uses port 1337 or 8080, please change its port to something else or uninstall it.
+- Sometimes Decky will disappear on SteamOS updates. This can easily be fixed by just re-running the installer and installing the stable branch again. If this doesn't work, try installing the prerelease instead. If that doesn't work, then [check the existing issues](https://github.com/PartyWumpus/decky-loader/issues) and if there isn't one then you can [file a new issue](https://github.com/PartyWumpus/decky-loader/issues/new?assignees=&labels=bug&template=bug_report.yml&title=%5BBUG%5D+%3Ctitle%3E).
 
 ## 💾 Installation
 - This installation can be done without an admin/sudo password set.


### PR DESCRIPTION
- tell users to install by dragging onto the desktop, as this is easier and more consistent.
- remove crankshaft warning in common issues
- fix dead link
- give link to installer in the installation steps instead of just telling people to click the button at the top
- clarify how temporary password works