### PR TITLE
Make patch notes modal only show current branch

### DIFF
--- a/backend/updater.py
+++ b/backend/updater.py
@@ -106,10 +106,10 @@ class Updater:
                 remoteVersions = await res.json()
                 if selectedBranch == 0:
                     logger.debug("release type: release")
-                    remoteVersions = filter(lambda ver: ver["tag_name"].startswith("v") and not ver["prerelease"] and not ver["tag_name"].find("-pre") > 0 and ver["tag_name"], remoteVersions)
+                    remoteVersions = list(filter(lambda ver: ver["tag_name"].startswith("v") and not ver["prerelease"] and not ver["tag_name"].find("-pre") > 0 and ver["tag_name"], remoteVersions))
                 elif selectedBranch == 1:
                     logger.debug("release type: pre-release")
-                    remoteVersions = filter(lambda ver:ver["tag_name"].startswith("v"), remoteVersions)
+                    remoteVersions = list(filter(lambda ver:ver["tag_name"].startswith("v"), remoteVersions))
                 else:
                     logger.error("release type: NOT FOUND")
                     raise ValueError("no valid branch found")

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -104,6 +104,15 @@ class Updater:
         async with ClientSession() as web:
             async with web.request("GET", "https://api.github.com/repos/SteamDeckHomebrew/decky-loader/releases", ssl=helpers.get_ssl_context()) as res:
                 remoteVersions = await res.json()
+                if selectedBranch == 0:
+                    logger.debug("release type: release")
+                    remoteVersions = filter(lambda ver: ver["tag_name"].startswith("v") and not ver["prerelease"] and not ver["tag_name"].find("-pre") > 0 and ver["tag_name"], remoteVersions)
+                elif selectedBranch == 1:
+                    logger.debug("release type: pre-release")
+                    remoteVersions = filter(lambda ver:ver["tag_name"].startswith("v"), remoteVersions)
+                else:
+                    logger.error("release type: NOT FOUND")
+                    raise ValueError("no valid branch found")
         self.allRemoteVers = remoteVersions
         logger.debug("determining release type to find, branch is %i" % selectedBranch)
         if selectedBranch == 0:

--- a/frontend/src/components/settings/pages/general/Updater.tsx
+++ b/frontend/src/components/settings/pages/general/Updater.tsx
@@ -39,7 +39,7 @@ function PatchNotesModal({ versionInfo, closeModal }: { versionInfo: VerInfo | n
               }}
             >
               <div>
-                <h1>{versionInfo?.all?.[id]?.name}</h1>
+                <h1>{versionInfo?.all?.[id]?.name || 'Invalid Update Name'}</h1>
                 {versionInfo?.all?.[id]?.body ? (
                   <WithSuspense>
                     <MarkdownRenderer onDismiss={closeModal}>{versionInfo.all[id].body}</MarkdownRenderer>


### PR DESCRIPTION
Spent *way* too long on this, but hey its done and i can finally move onto other things.

Currently, this achieves this by filtering the `remoteVersions` list in python, however it could eventually be refactored to only filter what is returned to the frontend, that way the backend always has the full dataset