### PR TITLE
add `inlang` to make the contribution of translations easier + no maintenance

### DIFF
--- a/inlang.config.js
+++ b/inlang.config.js
@@ -1,0 +1,17 @@
+export async function defineConfig(env) {
+	const { default: pluginJson } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/samuelstroschein/inlang-plugin-json@2/dist/index.js'
+	);
+
+	const { default: standardLintRules } = await env.$import(
+		'https://cdn.jsdelivr.net/gh/inlang/standard-lint-rules@2/dist/index.js'
+	);
+
+	return {
+		referenceLanguage: 'en-US',
+		plugins: [pluginJson({ 
+			pathPattern: './backend/locales/{language}.json',
+			variableReferencePattern: ["{{", "}}"]
+		}), standardLintRules()]
+	};
+}


### PR DESCRIPTION
I stumbled over this PR: https://github.com/SteamDeckHomebrew/decky-loader/pull/361 This could enhance the i18n support even more.

### Description
This pull request adds the possibility for contributors and translators to manage translations in a UI instead of files with no overhead for the maintainers.

To get a UI for translations contained in this repository, an [inlang.config.js](https://inlang.com/documentation/config) has been created at the root of the repository.

### Preview
The changes of this PR and a live instance of the editor can be previewed with the following link https://inlang.com/editor/github.com/NilsJacobsen/decky-loader/. Note: This link should be changed to point to decky-loader instead of NilsJacobsen after this PR has been merged.

### Limitations
**Certain actions are slow**
Inlang is running entirely on git, giving tremendous CI/CD and contribution power to localization (and potentially other verticals -> [the next git](https://www.youtube.com/watch?v=vJ3jGgCrz2I)). That means that the whole decky-loader repo is cloned into the browser which makes certain actions like the initial load and pushing changes slow. Those limitations will be fixed with future releases and require no input from decky-loader.

![pika-1680686287719-1x](https://user-images.githubusercontent.com/58360188/232016041-ec0c3da3-94a9-4492-85dd-d8478c66d945.jpeg)

### Badge
If you want to show the contributor the status of the translations, you could add a badge to your readme.
```
[![translation badge](https://inlang.com/badge?url=github.com/SteamDeckHomebrew/decky-loader)](https://inlang.com/editor/github.com/SteamDeckHomebrew/decky-loader?ref=badge)
```

Preview the messages on https://inlang.com/github.com/NilsJacobsen/decky-loader .