### PR TITLE
Add env var to not replace systemd service file

### DIFF
--- a/backend/localplatform.py
+++ b/backend/localplatform.py
@@ -32,7 +32,10 @@ def get_server_port() -> int:
     return int(os.getenv("SERVER_PORT", "1337"))
 
 def get_live_reload() -> bool:
-    os.getenv("LIVE_RELOAD", "1") == "1"
+    return os.getenv("LIVE_RELOAD", "1") == "1"
+
+def get_keep_systemd_service() -> bool:
+    return os.getenv("KEEP_SYSTEMD_SERVICE", "0") == "1"
 
 def get_log_level() -> int:
     return {"CRITICAL": 50, "ERROR": 40, "WARNING": 30, "INFO": 20, "DEBUG": 10}[

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -6,7 +6,7 @@ from ensurepip import version
 from json.decoder import JSONDecodeError
 from logging import getLogger
 from os import getcwd, path, remove
-from localplatform import chmod, service_restart, ON_LINUX
+from localplatform import chmod, service_restart, ON_LINUX, get_keep_systemd_service
 
 from aiohttp import ClientSession, web
 
@@ -159,7 +159,7 @@ class Updater:
         tab = await get_gamepadui_tab()
         await tab.open_websocket()
         async with ClientSession() as web:
-            if ON_LINUX:
+            if ON_LINUX and not get_keep_systemd_service():
                 logger.debug("Downloading systemd service")
                 # download the relevant systemd service depending upon branch
                 async with web.request("GET", service_url, ssl=helpers.get_ssl_context(), allow_redirects=True) as res:


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [X] This is a new feature

# Description

This adds an environment variable that stops decky from updating it's systemd unit/config, so any configuration in it will not be lost. Default behaviour stays the same: the systemd unit/config gets updated every time decky updates

Tl;dr: Simply add `Environment=KEEP_SYSTEMD_SERVICE=1` to decky's systemd unit/config to stop it from being overwritten


PS: This also fixes a bug where the LIVE_RELOAD environment variable was ineffective