### PR TITLE
Add functionality to hide plugins from quick access menu

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -122,10 +122,7 @@ class PluginBrowser:
                 logger.debug("Plugin %s was stopped", name)
                 del self.plugins[name]
                 logger.debug("Plugin %s was removed from the dictionary", name)
-                current_plugin_order = self.settings.getSetting("pluginOrder")
-                current_plugin_order.remove(name)
-                self.settings.setSetting("pluginOrder", current_plugin_order)
-                logger.debug("Plugin %s was removed from the pluginOrder setting", name)
+                self.cleanup_plugin_settings(name)
             logger.debug("removing files %s" % str(name))
             rmtree(plugin_dir)
         except FileNotFoundError:
@@ -234,3 +231,18 @@ class PluginBrowser:
 
     def cancel_plugin_install(self, request_id):
         self.install_requests.pop(request_id)
+
+    def cleanup_plugin_settings(self, name):
+        """Removes any settings related to a plugin. Propably called when a plugin is uninstalled.
+
+        Args:
+            name (string): The name of the plugin
+        """
+        hidden_plugins = self.settings.getSetting("hiddenPlugins", [])
+        hidden_plugins.remove(name)
+        self.settings.setSetting("hiddenPlugins", hidden_plugins)
+
+        plugin_order = self.settings.getSetting("pluginOrder")
+        plugin_order.remove(name)
+        self.settings.setSetting("pluginOrder", plugin_order)
+        logger.debug("Removed any settings for plugin %s", name)

--- a/backend/locales/en-US.json
+++ b/backend/locales/en-US.json
@@ -17,6 +17,13 @@
             "select": "Use this folder"
         }
     },
+    "PluginView": {
+        "hidden_one": "1 plugin is hidden from this list",
+        "hidden_other": "{{count}} plugins are hidden from this list"
+    },
+    "PluginListLabel": {
+        "hidden": "Hidden from the quick access menu"
+    },
     "PluginCard": {
         "plugin_full_access": "This plugin has full access to your Steam Deck.",
         "plugin_install": "Install",
@@ -73,6 +80,8 @@
         "reload": "Reload",
         "uninstall": "Uninstall",
         "update_to": "Update to {{name}}",
+        "show": "Quick access: Show",
+        "hide": "Quick access: Hide",
         "update_all_one": "Update 1 plugin",
         "update_all_other": "Update {{count}} plugins"
     },

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -22,7 +22,7 @@ class SettingsManager:
         for file in listdir(wrong_dir):
             if file.endswith(".json"):
                 rename(path.join(wrong_dir,file),
-                       path.join(settings_directory, file)) 
+                       path.join(settings_directory, file))
                 self.path = path.join(settings_directory, name + ".json")
 
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 
 .yalc
 yalc.lock
+
+stats.html

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "rollup-plugin-delete": "^2.0.0",
     "rollup-plugin-external-globals": "^0.6.1",
     "rollup-plugin-polyfill-node": "^0.10.2",
+    "rollup-plugin-visualizer": "^5.9.0",
     "tslib": "^2.5.2",
     "typescript": "^4.9.5"
   },
@@ -43,7 +44,7 @@
     }
   },
   "dependencies": {
-    "decky-frontend-lib": "3.20.7",
+    "decky-frontend-lib": "3.21.1",
     "i18next": "^22.5.0",
     "i18next-http-backend": "^2.2.1",
     "react-file-icon": "^1.3.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -2,8 +2,8 @@ lockfileVersion: '6.0'
 
 dependencies:
   decky-frontend-lib:
-    specifier: 3.20.7
-    version: 3.20.7
+    specifier: 3.21.1
+    version: 3.21.1
   i18next:
     specifier: ^22.5.0
     version: 22.5.0
@@ -93,6 +93,9 @@ devDependencies:
   rollup-plugin-polyfill-node:
     specifier: ^0.10.2
     version: 0.10.2(rollup@2.79.1)
+  rollup-plugin-visualizer:
+    specifier: ^5.9.0
+    version: 5.9.0(rollup@2.79.1)
   tslib:
     specifier: ^2.5.2
     version: 2.5.2
@@ -1235,6 +1238,15 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
+  /cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
   /clone-buffer@1.0.0:
     resolution: {integrity: sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==}
     engines: {node: '>= 0.10'}
@@ -1393,8 +1405,8 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /decky-frontend-lib@3.20.7:
-    resolution: {integrity: sha512-Zwwbo50cqpTbCfSCZaqITgTRvWs7pK9KO1A+Oo2sCC/DqOfyUtEH5niNPid4Qxu+yh4lsbEjTurJk1nCfd+nZw==}
+  /decky-frontend-lib@3.21.1:
+    resolution: {integrity: sha512-30605ET9qqZ6St6I9WmMmLGgSrTIdMwo7xy85+lRaF1miUd2icOGEJjwnbVcZDdkal+1fJ3tNEDXlchVfG4TrA==}
     dev: false
 
   /decode-named-character-reference@1.0.2:
@@ -1412,6 +1424,11 @@ packages:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
     dependencies:
       clone: 1.0.4
+    dev: true
+
+  /define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
     dev: true
 
   /define-properties@1.2.0:
@@ -1770,6 +1787,11 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
+  /get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+    dev: true
+
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
@@ -2126,6 +2148,12 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
+  /is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dev: true
+
   /is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2220,6 +2248,13 @@ packages:
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+    dependencies:
+      is-docker: 2.2.1
     dev: true
 
   /isarray@1.0.0:
@@ -2891,6 +2926,15 @@ packages:
       mimic-fn: 2.1.0
     dev: true
 
+  /open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+    engines: {node: '>=12'}
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
+    dev: true
+
   /ora@5.4.1:
     resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
     engines: {node: '>=10'}
@@ -3237,6 +3281,11 @@ packages:
     engines: {node: '>= 10'}
     dev: true
 
+  /require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+    dev: true
+
   /resolve-from@3.0.0:
     resolution: {integrity: sha512-GnlH6vxLymXJNMBo7XP1fJIzBFbdYt49CuTwmB/6N53t+kMPRMFKz783LlQ4tv28XoQfMWinAJX6WCGf2IlaIw==}
     engines: {node: '>=4'}
@@ -3316,6 +3365,23 @@ packages:
     dependencies:
       '@rollup/plugin-inject': 4.0.4(rollup@2.79.1)
       rollup: 2.79.1
+    dev: true
+
+  /rollup-plugin-visualizer@5.9.0(rollup@2.79.1):
+    resolution: {integrity: sha512-bbDOv47+Bw4C/cgs0czZqfm8L82xOZssk4ayZjG40y9zbXclNk7YikrZTDao6p7+HDiGxrN0b65SgZiVm9k1Cg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      rollup: 2.x || 3.x
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+    dependencies:
+      open: 8.4.2
+      picomatch: 2.3.1
+      rollup: 2.79.1
+      source-map: 0.7.4
+      yargs: 17.7.2
     dev: true
 
   /rollup@2.79.1:
@@ -3423,6 +3489,11 @@ packages:
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /source-map@0.7.4:
+    resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
+    engines: {node: '>= 8'}
     dev: true
 
   /sourcemap-codec@1.4.8:
@@ -3958,8 +4029,31 @@ packages:
     engines: {node: '>=0.4'}
     dev: true
 
+  /y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+    dev: true
+
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
+
+  /yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+    dev: true
+
+  /yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
     dev: true
 
   /zwitch@2.0.4:

--- a/frontend/rollup.config.js
+++ b/frontend/rollup.config.js
@@ -7,6 +7,7 @@ import typescript from '@rollup/plugin-typescript';
 import { defineConfig } from 'rollup';
 import del from 'rollup-plugin-delete';
 import externalGlobals from 'rollup-plugin-external-globals';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 const hiddenWarnings = ['THIS_IS_UNDEFINED', 'EVAL'];
 
@@ -16,7 +17,7 @@ export default defineConfig({
     del({ targets: '../backend/static/*', force: true }),
     commonjs(),
     nodeResolve({
-      browser: true
+      browser: true,
     }),
     externalGlobals({
       react: 'SP_REACT',
@@ -33,6 +34,7 @@ export default defineConfig({
       'process.env.NODE_ENV': JSON.stringify('production'),
     }),
     image(),
+    visualizer(),
   ],
   preserveEntrySignatures: false,
   output: {

--- a/frontend/src/components/DeckyState.tsx
+++ b/frontend/src/components/DeckyState.tsx
@@ -7,6 +7,7 @@ import { VerInfo } from '../updater';
 interface PublicDeckyState {
   plugins: Plugin[];
   pluginOrder: string[];
+  hiddenPlugins: string[];
   activePlugin: Plugin | null;
   updates: PluginUpdateMapping | null;
   hasLoaderUpdate?: boolean;
@@ -17,6 +18,7 @@ interface PublicDeckyState {
 export class DeckyState {
   private _plugins: Plugin[] = [];
   private _pluginOrder: string[] = [];
+  private _hiddenPlugins: string[] = [];
   private _activePlugin: Plugin | null = null;
   private _updates: PluginUpdateMapping | null = null;
   private _hasLoaderUpdate: boolean = false;
@@ -29,6 +31,7 @@ export class DeckyState {
     return {
       plugins: this._plugins,
       pluginOrder: this._pluginOrder,
+      hiddenPlugins: this._hiddenPlugins,
       activePlugin: this._activePlugin,
       updates: this._updates,
       hasLoaderUpdate: this._hasLoaderUpdate,
@@ -49,6 +52,11 @@ export class DeckyState {
 
   setPluginOrder(pluginOrder: string[]) {
     this._pluginOrder = pluginOrder;
+    this.notifyUpdate();
+  }
+
+  setHiddenPlugins(hiddenPlugins: string[]) {
+    this._hiddenPlugins = hiddenPlugins;
     this.notifyUpdate();
   }
 
@@ -111,11 +119,11 @@ export const DeckyStateContextProvider: FC<Props> = ({ children, deckyState }) =
     return () => deckyState.eventBus.removeEventListener('update', onUpdate);
   }, []);
 
-  const setIsLoaderUpdating = (hasUpdate: boolean) => deckyState.setIsLoaderUpdating(hasUpdate);
-  const setVersionInfo = (versionInfo: VerInfo) => deckyState.setVersionInfo(versionInfo);
-  const setActivePlugin = (name: string) => deckyState.setActivePlugin(name);
-  const closeActivePlugin = () => deckyState.closeActivePlugin();
-  const setPluginOrder = (pluginOrder: string[]) => deckyState.setPluginOrder(pluginOrder);
+  const setIsLoaderUpdating = deckyState.setIsLoaderUpdating.bind(deckyState);
+  const setVersionInfo = deckyState.setVersionInfo.bind(deckyState);
+  const setActivePlugin = deckyState.setActivePlugin.bind(deckyState);
+  const closeActivePlugin = deckyState.closeActivePlugin.bind(deckyState);
+  const setPluginOrder = deckyState.setPluginOrder.bind(deckyState);
 
   return (
     <DeckyStateContext.Provider

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -8,6 +8,8 @@ import {
   staticClasses,
 } from 'decky-frontend-lib';
 import { VFC, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaEyeSlash } from 'react-icons/fa';
 
 import { Plugin } from '../plugin';
 import { useDeckyState } from './DeckyState';
@@ -16,8 +18,10 @@ import { useQuickAccessVisible } from './QuickAccessVisibleState';
 import TitleView from './TitleView';
 
 const PluginView: VFC = () => {
+  const { hiddenPlugins } = useDeckyState();
   const { plugins, updates, activePlugin, pluginOrder, setActivePlugin, closeActivePlugin } = useDeckyState();
   const visible = useQuickAccessVisible();
+  const { t } = useTranslation();
 
   const [pluginList, setPluginList] = useState<Plugin[]>(
     plugins.sort((a, b) => pluginOrder.indexOf(a.name) - pluginOrder.indexOf(b.name)),
@@ -48,6 +52,7 @@ const PluginView: VFC = () => {
         <PanelSection>
           {pluginList
             .filter((p) => p.content)
+            .filter(({ name }) => !hiddenPlugins.includes(name))
             .map(({ name, icon }) => (
               <PanelSectionRow key={name}>
                 <ButtonItem layout="below" onClick={() => setActivePlugin(name)}>
@@ -59,6 +64,12 @@ const PluginView: VFC = () => {
                 </ButtonItem>
               </PanelSectionRow>
             ))}
+          {hiddenPlugins.length > 0 && (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', fontSize: '0.8rem', marginTop: '10px' }}>
+              <FaEyeSlash />
+              <div>{t('PluginView.hidden', { count: hiddenPlugins.length })}</div>
+            </div>
+          )}
         </PanelSection>
       </div>
     </>

--- a/frontend/src/components/modals/PluginUninstallModal.tsx
+++ b/frontend/src/components/modals/PluginUninstallModal.tsx
@@ -1,0 +1,30 @@
+import { ConfirmModal } from 'decky-frontend-lib';
+import { FC } from 'react';
+
+interface PluginUninstallModalProps {
+  name: string;
+  title: string;
+  buttonText: string;
+  description: string;
+  closeModal?(): void;
+}
+
+const PluginUninstallModal: FC<PluginUninstallModalProps> = ({ name, title, buttonText, description, closeModal }) => {
+  return (
+    <ConfirmModal
+      closeModal={closeModal}
+      onOK={async () => {
+        await window.DeckyPluginLoader.callServerMethod('uninstall_plugin', { name });
+        // uninstalling a plugin resets the hidden setting for it server-side
+        // we invalidate here so if you re-install it, you won't have an out-of-date hidden filter
+        await window.DeckyPluginLoader.hiddenPluginsService.invalidate();
+      }}
+      strTitle={title}
+      strOKButtonText={buttonText}
+    >
+      {description}
+    </ConfirmModal>
+  );
+};
+
+export default PluginUninstallModal;

--- a/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
@@ -1,0 +1,34 @@
+import { FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FaEyeSlash } from 'react-icons/fa';
+
+interface PluginListLabelProps {
+  hidden: boolean;
+  name: string;
+  version?: string;
+}
+
+const PluginListLabel: FC<PluginListLabelProps> = ({ name, hidden, version }) => {
+  const { t } = useTranslation();
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+      <div>{version ? `${name} - ${version}` : name}</div>
+      {hidden && (
+        <div
+          style={{
+            fontSize: '0.8rem',
+            color: '#dcdedf',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+          }}
+        >
+          <FaEyeSlash />
+          {t('PluginListLabel.hidden')}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PluginListLabel;

--- a/frontend/src/hidden-plugins-service.tsx
+++ b/frontend/src/hidden-plugins-service.tsx
@@ -1,0 +1,34 @@
+import { DeckyState } from './components/DeckyState';
+import { getSetting, setSetting } from './utils/settings';
+
+/**
+ * A Service class for managing the state and actions related to the hidden plugins feature
+ *
+ * It's mostly responsible for sending setting updates to the server and keeping the local state in sync.
+ */
+export class HiddenPluginsService {
+  constructor(private deckyState: DeckyState) {}
+
+  init() {
+    getSetting<string[]>('hiddenPlugins', []).then((hiddenPlugins) => {
+      this.deckyState.setHiddenPlugins(hiddenPlugins);
+    });
+  }
+
+  /**
+   * Sends the new hidden plugins list to the server and persists it locally in the decky state
+   *
+   * @param hiddenPlugins The new list of hidden plugins
+   */
+  async update(hiddenPlugins: string[]) {
+    await setSetting('hiddenPlugins', hiddenPlugins);
+    this.deckyState.setHiddenPlugins(hiddenPlugins);
+  }
+
+  /**
+   * Refreshes the state of hidden plugins in the local state
+   */
+  async invalidate() {
+    this.deckyState.setHiddenPlugins(await getSetting('hiddenPlugins', []));
+  }
+}

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -1,5 +1,4 @@
 import {
-  ConfirmModal,
   ModalRoot,
   PanelSection,
   PanelSectionRow,
@@ -18,9 +17,11 @@ import LegacyPlugin from './components/LegacyPlugin';
 import { deinitFilepickerPatches, initFilepickerPatches } from './components/modals/filepicker/patches';
 import MultiplePluginsInstallModal from './components/modals/MultiplePluginsInstallModal';
 import PluginInstallModal from './components/modals/PluginInstallModal';
+import PluginUninstallModal from './components/modals/PluginUninstallModal';
 import NotificationBadge from './components/NotificationBadge';
 import PluginView from './components/PluginView';
 import WithSuspense from './components/WithSuspense';
+import { HiddenPluginsService } from './hidden-plugins-service';
 import Logger from './logger';
 import { InstallType, Plugin } from './plugin';
 import RouterHook from './router-hook';
@@ -45,6 +46,7 @@ class PluginLoader extends Logger {
   private routerHook: RouterHook = new RouterHook();
   public toaster: Toaster = new Toaster();
   private deckyState: DeckyState = new DeckyState();
+  public hiddenPluginsService = new HiddenPluginsService(this.deckyState);
 
   private reloadLock: boolean = false;
   // stores a list of plugin names which requested to be reloaded
@@ -182,21 +184,8 @@ class PluginLoader extends Logger {
     );
   }
 
-  public uninstallPlugin(name: string, title: string, button_text: string, description: string) {
-    showModal(
-      <ConfirmModal
-        onOK={async () => {
-          await this.callServerMethod('uninstall_plugin', { name });
-        }}
-        onCancel={() => {
-          // do nothing
-        }}
-        strTitle={title}
-        strOKButtonText={button_text}
-      >
-        {description}
-      </ConfirmModal>,
-    );
+  public uninstallPlugin(name: string, title: string, buttonText: string, description: string) {
+    showModal(<PluginUninstallModal name={name} title={title} buttonText={buttonText} description={description} />);
   }
 
   public hasPlugin(name: string) {
@@ -220,6 +209,8 @@ class PluginLoader extends Logger {
       console.log(pluginOrder);
       this.deckyState.setPluginOrder(pluginOrder);
     });
+
+    this.hiddenPluginsService.init();
   }
 
   public deinit() {


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #317 

TODO:
- [x] Add a way to synchronize settings across `useSettings` calls
- [x] On uninstall of a plugin, also remove it from the settings key.

# Screenshots

![image](https://github.com/SteamDeckHomebrew/decky-loader/assets/3109892/de96ec17-f864-4d33-b085-0836d8479c59)
![image](https://github.com/SteamDeckHomebrew/decky-loader/assets/3109892/491449ed-3133-403f-87be-5a7e0395b375)
![image](https://github.com/SteamDeckHomebrew/decky-loader/assets/3109892/92043951-73de-4df4-aec7-6908393e27f5)

