### PR TITLE
When decky is uncertain of branch, set the setting to match the guess

### DIFF
--- a/backend/updater.py
+++ b/backend/updater.py
@@ -67,9 +67,11 @@ class Updater:
             logger.info("Current branch is not set, determining branch from version...")
             if self.localVer.startswith("v") and "-pre" in self.localVer:
                 logger.info("Current version determined to be pre-release")
+                manager.setSetting('branch', 1)
                 return 1
             else:
                 logger.info("Current version determined to be stable")
+                manager.setSetting('branch', 0)
                 return 0
         return ver
 

--- a/frontend/src/components/settings/pages/general/BranchSelect.tsx
+++ b/frontend/src/components/settings/pages/general/BranchSelect.tsx
@@ -21,7 +21,7 @@ const BranchSelect: FunctionComponent<{}> = () => {
     t('BranchSelect.update_channel.prerelease'),
     t('BranchSelect.update_channel.testing'),
   ];
-  const [selectedBranch, setSelectedBranch] = useSetting<UpdateBranch>('branch', UpdateBranch.Prerelease);
+  const [selectedBranch, setSelectedBranch] = useSetting<UpdateBranch>('branch', UpdateBranch.Stable);
 
   return (
     // Returns numerical values from 0 to 2 (with current branch setup as of 8/28/22)


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #472
This issue should only happen on new installs where the branch isn't set in settings, but might fix other situations too.