### PR TITLE
Fix uninstalling plugins

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -129,7 +129,7 @@ class PluginBrowser:
             logger.warning(f"Plugin {name} not installed, skipping uninstallation")
         except Exception as e:
             logger.error(f"Plugin {name} in {plugin_dir} was not uninstalled")
-            logger.error(f"Error at %s", exc_info=e)
+            logger.error(f"Error at {str(e)}", exc_info=e)
         if self.loader.watcher:
             self.loader.watcher.disabled = False
 

--- a/backend/browser.py
+++ b/backend/browser.py
@@ -239,10 +239,15 @@ class PluginBrowser:
             name (string): The name of the plugin
         """
         hidden_plugins = self.settings.getSetting("hiddenPlugins", [])
-        hidden_plugins.remove(name)
-        self.settings.setSetting("hiddenPlugins", hidden_plugins)
+        if name in hidden_plugins:
+            hidden_plugins.remove(name)
+            self.settings.setSetting("hiddenPlugins", hidden_plugins)
 
-        plugin_order = self.settings.getSetting("pluginOrder")
-        plugin_order.remove(name)
-        self.settings.setSetting("pluginOrder", plugin_order)
+
+        plugin_order = self.settings.getSetting("pluginOrder", [])
+
+        if name in plugin_order:
+            plugin_order.remove(name)
+            self.settings.setSetting("pluginOrder", plugin_order)
+            
         logger.debug("Removed any settings for plugin %s", name)


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issue: When uninstalling a plugin on latest release, it fails as it's trying to remove an element from a list that may not exist in said list (specifically, the list that tracks hidden plugins). This pull request fixes that.
