### PR TITLE
Add descriptions to Decky titleview DialogButtons

### DIFF
--- a/backend/locales/en-US.json
+++ b/backend/locales/en-US.json
@@ -234,6 +234,10 @@
       "testing": "Testing"
     }
   },
+  "TitleView":{
+    "decky_store_desc": "Open Decky Store",
+    "settings_desc": "Open Decky Settings"
+  },
   "Updater": {
     "decky_updates": "Decky Updates",
     "no_patch_notes_desc": "no patch notes for this version",

--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -31,12 +31,14 @@ const TitleView: VFC = () => {
         <DialogButton
           style={{ height: '28px', width: '40px', minWidth: 0, padding: '10px 12px' }}
           onClick={onStoreClick}
+          onOKActionDescription={'Open Decky Store'}
         >
           <FaStore style={{ marginTop: '-4px', display: 'block' }} />
         </DialogButton>
         <DialogButton
           style={{ height: '28px', width: '40px', minWidth: 0, padding: '10px 12px' }}
           onClick={onSettingsClick}
+          onOKActionDescription={'Open Decky Settings'}
         >
           <BsGearFill style={{ marginTop: '-4px', display: 'block' }} />
         </DialogButton>

--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -1,5 +1,6 @@
 import { DialogButton, Focusable, Router, staticClasses } from 'decky-frontend-lib';
 import { CSSProperties, VFC } from 'react';
+import { useTranslation } from 'react-i18next';
 import { BsGearFill } from 'react-icons/bs';
 import { FaArrowLeft, FaStore } from 'react-icons/fa';
 
@@ -13,6 +14,7 @@ const titleStyles: CSSProperties = {
 
 const TitleView: VFC = () => {
   const { activePlugin, closeActivePlugin } = useDeckyState();
+  const { t } = useTranslation();
 
   const onSettingsClick = () => {
     Router.CloseSideMenus();
@@ -31,14 +33,14 @@ const TitleView: VFC = () => {
         <DialogButton
           style={{ height: '28px', width: '40px', minWidth: 0, padding: '10px 12px' }}
           onClick={onStoreClick}
-          onOKActionDescription={'Open Decky Store'}
+          onOKActionDescription={t('TitleView.decky_store_desc')}
         >
           <FaStore style={{ marginTop: '-4px', display: 'block' }} />
         </DialogButton>
         <DialogButton
           style={{ height: '28px', width: '40px', minWidth: 0, padding: '10px 12px' }}
           onClick={onSettingsClick}
-          onOKActionDescription={'Open Decky Settings'}
+          onOKActionDescription={t('TitleView.settings_desc')}
         >
           <BsGearFill style={{ marginTop: '-4px', display: 'block' }} />
         </DialogButton>


### PR DESCRIPTION
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [X] This is a new feature

# Description
This simple PR is in preparation for custom titleviews. Since plugins may reuse the same icons or use ones that aren't universally recognized, it will be a good practice to disambiguate Decky's buttons with labels. This also has precedence in the Steam UI, where any icon-only button has a matching description. 