### PR TITLE
Bugfix: Unable to load _sqlite3 on main SteamOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install Python dependencies ⬇️
       run: |
         python -m pip install --upgrade pip
-        pip install pyinstaller==5.5
+        pip install pyinstaller==5.13.0
         [ -f requirements.txt ] && pip install -r requirements.txt
 
     - name: Install JS dependencies ⬇️
@@ -105,7 +105,7 @@ jobs:
     - name: Install Python dependencies ⬇️
       run: |
         python -m pip install --upgrade pip
-        pip install pyinstaller==5.5
+        pip install pyinstaller==5.13.0
         pip install -r requirements.txt
 
     - name: Install JS dependencies ⬇️

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.8.5
+aiohttp==3.8.4
 aiohttp-jinja2==1.5.1
 aiohttp_cors==0.7.0
 watchdog==2.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp==3.8.1
-aiohttp-jinja2==1.5.0
+aiohttp==3.8.5
+aiohttp-jinja2==1.5.1
 aiohttp_cors==0.7.0
 watchdog==2.1.7
 certifi==2022.12.7


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description
While using Decky on main OS, I discovered that SDH-PlayTime was failing to load throwing an sqlite import error. After updating Python to the latest stable, AIOHttp to the latest to allow to compile it correctly and PyInstaller in order to make it actually produce a runnable binary version, SDH-PlayTime started to work again fine.

This need to be tested on other OS version and with different plugin, but for my initial testing it seems to work perfectly fine.