### PR TITLE
Add Custom `TitleView`

### DIFF
--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -52,7 +52,11 @@ const TitleView: VFC = () => {
       >
         <FaArrowLeft style={{ marginTop: '-4px', display: 'block' }} />
       </DialogButton>
-      <div style={{ flex: 0.9 }}>{activePlugin.name}</div>
+      {activePlugin?.titleView ? (
+        <div style={{ flex: 0.9 }}>{activePlugin.titleView}</div>
+      ) : (
+        <div style={{ flex: 0.9 }}>{activePlugin.name}</div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -52,11 +52,7 @@ const TitleView: VFC = () => {
       >
         <FaArrowLeft style={{ marginTop: '-4px', display: 'block' }} />
       </DialogButton>
-      {activePlugin?.titleView ? (
-        <div style={{ flex: 0.9 }}>{activePlugin.titleView}</div>
-      ) : (
-        <div style={{ flex: 0.9 }}>{activePlugin.name}</div>
-      )}
+      {activePlugin?.titleView || <div style={{ flex: 0.9 }}>{activePlugin.name}</div>}
     </Focusable>
   );
 };

--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -45,7 +45,7 @@ const TitleView: VFC = () => {
   }
 
   return (
-    <div className={staticClasses.Title} style={titleStyles}>
+    <Focusable className={staticClasses.Title} style={titleStyles}>
       <DialogButton
         style={{ height: '28px', width: '40px', minWidth: 0, padding: '10px 12px' }}
         onClick={closeActivePlugin}
@@ -57,7 +57,7 @@ const TitleView: VFC = () => {
       ) : (
         <div style={{ flex: 0.9 }}>{activePlugin.name}</div>
       )}
-    </div>
+    </Focusable>
   );
 };
 

--- a/frontend/src/plugin.ts
+++ b/frontend/src/plugin.ts
@@ -5,6 +5,7 @@ export interface Plugin {
   content?: JSX.Element;
   onDismount?(): void;
   alwaysRender?: boolean;
+  titleView?: JSX.Element;
 }
 
 export enum InstallType {


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description

This is an addition that allows plugin developers to change the titleView of their plugin. Currently, it is just a `<div style={{ flex: 0.9 }}>{activePlugin.name}</div>`. If a plugin has the `titleView` prop in their definePlugin return value, it will now display that instead of the boilerplate name.

This does not allow for removal of the back button, as that is crucial to ensuring people can exit out of plugins, the custom titleView slots in to the right of the back button.
