### PR TITLE
Make the updater work properly on SELinux

### DIFF
--- a/backend/localplatform.py
+++ b/backend/localplatform.py
@@ -41,3 +41,6 @@ def get_log_level() -> int:
     return {"CRITICAL": 50, "ERROR": 40, "WARNING": 30, "INFO": 20, "DEBUG": 10}[
         os.getenv("LOG_LEVEL", "INFO")
     ]
+
+def get_selinux() -> bool:
+    return os.getenv("DECKY_SELINUX", "0") == "1"

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -210,7 +210,7 @@ class Updater:
                 chmod(path.join(getcwd(), download_filename), 777, False)
                 if get_selinux():
                     from subprocess import call
-                    call(["chcon", "-R", "-t", "bin_t", path.join(getcwd(), download_filename)])
+                    call(["chcon", "-t", "bin_t", path.join(getcwd(), download_filename)])
 
             logger.info("Updated loader installation.")
             await tab.evaluate_js("window.DeckyUpdater.finish()", False, False)

--- a/backend/updater.py
+++ b/backend/updater.py
@@ -6,7 +6,7 @@ from ensurepip import version
 from json.decoder import JSONDecodeError
 from logging import getLogger
 from os import getcwd, path, remove
-from localplatform import chmod, service_restart, ON_LINUX, get_keep_systemd_service
+from localplatform import chmod, service_restart, ON_LINUX, get_keep_systemd_service, get_selinux
 
 from aiohttp import ClientSession, web
 
@@ -208,6 +208,9 @@ class Updater:
                 remove(path.join(getcwd(), download_filename))
                 shutil.move(path.join(getcwd(), download_temp_filename), path.join(getcwd(), download_filename))
                 chmod(path.join(getcwd(), download_filename), 777, False)
+                if get_selinux():
+                    from subprocess import call
+                    call(["chcon", "-R", "-t", "bin_t", path.join(getcwd(), download_filename)])
 
             logger.info("Updated loader installation.")
             await tab.evaluate_js("window.DeckyUpdater.finish()", False, False)


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC (sort of, but only to see if there's any regressions)
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [x] This is a new feature (adds a new env var)

# Description

This fixes the issue for SELinux users where the loader would not make itself executable.

If a user sets the env var `DECKY_SELINUX` = `1` it will make decky run `chcon` on the new executable file, allowing it to work (on selinux). I'll merge this once it's been tested by someone who uses selinux.