### PR TITLE
Split windows workflow

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -44,9 +44,15 @@ jobs:
 
     - name: Build Python Backend 🛠️
       run: pyinstaller --noconfirm --onefile --name "PluginLoader" --add-data "./backend/static;/static" --add-data "./backend/locales;/locales" --add-data "./backend/legacy;/legacy" --add-data "./plugin;/plugin" --hidden-import=sqlite3 ./backend/main.py
+
+    - name: Build Python Backend (noconsole) 🛠️
+      run: pyinstaller --noconfirm --noconsole --onefile --name "PluginLoader_noconsole" --add-data "./backend/static;/static" --add-data "./backend/locales;/locales" --add-data "./backend/legacy;/legacy" --add-data "./plugin;/plugin" --hidden-import=sqlite3 ./backend/main.py
         
     - name: Upload package artifact ⬆️
       uses: actions/upload-artifact@v3
       with:
         name: PluginLoader Win
-        path: ./dist/PluginLoader.exe
+        path: |
+          ./dist/PluginLoader.exe
+          ./dist/PluginLoader_noconsole.exe
+    

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,0 +1,52 @@
+name: Builder Win
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: write
+
+jobs:
+  build-win:
+    name: Build PluginLoader for Win
+    runs-on: windows-2022
+
+    steps:
+    - name: Checkout 🧰
+      uses: actions/checkout@v3
+
+    - name: Set up NodeJS 18 💎
+      uses: actions/setup-node@v3
+      with:
+        node-version: 18
+      
+    - name: Set up Python 3.11.4 🐍
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.11.4"
+        
+    - name: Install Python dependencies ⬇️
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyinstaller==5.13.0
+        pip install -r requirements.txt
+
+    - name: Install JS dependencies ⬇️
+      working-directory: ./frontend
+      run: |
+        npm i -g pnpm
+        pnpm i --frozen-lockfile
+
+    - name: Build JS Frontend 🛠️
+      working-directory: ./frontend
+      run: pnpm run build
+
+    - name: Build Python Backend 🛠️
+      run: pyinstaller --noconfirm --onefile --name "PluginLoader" --add-data "./backend/static;/static" --add-data "./backend/locales;/locales" --add-data "./backend/legacy;/legacy" --add-data "./plugin;/plugin" --hidden-import=sqlite3 ./backend/main.py
+        
+    - name: Upload package artifact ⬆️
+      uses: actions/upload-artifact@v3
+      with:
+        name: PluginLoader Win
+        path: ./dist/PluginLoader.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,49 +101,6 @@ jobs:
       with:
         path: ./dist/PluginLoader
 
-  build-win:
-    name: Build PluginLoader for Win
-    runs-on: windows-2022
-
-    steps:
-    - name: Checkout 🧰
-      uses: actions/checkout@v3
-
-    - name: Set up NodeJS 18 💎
-      uses: actions/setup-node@v3
-      with:
-        node-version: 18
-      
-    - name: Set up Python 3.11.4 🐍
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.11.4"
-        
-    - name: Install Python dependencies ⬇️
-      run: |
-        python -m pip install --upgrade pip
-        pip install pyinstaller==5.13.0
-        pip install -r requirements.txt
-
-    - name: Install JS dependencies ⬇️
-      working-directory: ./frontend
-      run: |
-        npm i -g pnpm
-        pnpm i --frozen-lockfile
-
-    - name: Build JS Frontend 🛠️
-      working-directory: ./frontend
-      run: pnpm run build
-
-    - name: Build Python Backend 🛠️
-      run: pyinstaller --noconfirm --onefile --name "PluginLoader" --add-data "./backend/static;/static" --add-data "./backend/locales;/locales" --add-data "./backend/legacy;/legacy" --add-data "./plugin;/plugin" --hidden-import=sqlite3 ./backend/main.py
-        
-    - name: Upload package artifact ⬆️
-      uses: actions/upload-artifact@v3
-      with:
-        name: PluginLoader Win
-        path: ./dist/PluginLoader.exe
-
   release:
     name: Release stable version of the package
     if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.release == 'release' }}


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
    - CI Change, not relevant
- [X] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes that a lot of time is spent waiting on windows CI builds, as it's now split into a seperate file/actions run. Also, this adds a console-less windows version of the pluginloader binary.
