### PR TITLE
Preserve plugin order when reinstalling/updating

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -139,6 +139,8 @@ class PluginBrowser:
 
         # Check if plugin is installed
         isInstalled = False
+        # Preserve plugin order before removing plugin (uninstall alters the order and removes the plugin from the list)
+        current_plugin_order = self.settings.getSetting("pluginOrder")[:]
         if self.loader.watcher:
             self.loader.watcher.disabled = True
         try:
@@ -191,9 +193,9 @@ class PluginBrowser:
                     self.loader.plugins[name].stop()
                     self.loader.plugins.pop(name, None)
                 await sleep(1)
-
-                current_plugin_order = self.settings.getSetting("pluginOrder")
-                current_plugin_order.append(name)
+                if not isInstalled:
+                    current_plugin_order = self.settings.getSetting("pluginOrder")
+                    current_plugin_order.append(name)
                 self.settings.setSetting("pluginOrder", current_plugin_order)
                 logger.debug("Plugin %s was added to the pluginOrder setting", name)
                 self.loader.import_plugin(path.join(plugin_dir, "main.py"), plugin_folder)


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #513

This change preserves the plugin order if the plugin is already installed and assumes that when calling _install on an already installed plugin, either reinstall/update was used and the entry should in theory still be there after install (this assumption can fail if the install fails). This should preserve the order across __full reboots__ and should be tested with full reboots after plugin changes (re-installs and updates, but no harm in checking plugin installs and deletions as well).