### PR TITLE
(bugfix) Handle SELinux permissions in the installer of Decky

### DIFF
--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -21,6 +21,10 @@ DOWNLOADURL=$(jq -r '.assets[].browser_download_url | select(endswith("PluginLoa
 printf "Installing version %s...\n" "${VERSION}"
 curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
+
+echo "Check for SELinux presence and if it is present, set the correct permission on the binary file..."
+hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && setenforce -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
+
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version
 
 systemctl --user stop plugin_loader 2> /dev/null

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -23,7 +23,7 @@ curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
 
 echo "Check for SELinux presence and if it is present, set the correct permission on the binary file..."
-hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && setenforce -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
+hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && chcon -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
 
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version
 

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -21,6 +21,10 @@ DOWNLOADURL=$(jq -r '.assets[].browser_download_url | select(endswith("PluginLoa
 printf "Installing version %s...\n" "${VERSION}"
 curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
+
+echo "Check for SELinux presence and if it is present, set the correct permission on the binary file..."
+hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && setenforce -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
+
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version
 
 systemctl --user stop plugin_loader 2> /dev/null

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -23,7 +23,7 @@ curl -L $DOWNLOADURL --output ${HOMEBREW_FOLDER}/services/PluginLoader
 chmod +x ${HOMEBREW_FOLDER}/services/PluginLoader
 
 echo "Check for SELinux presence and if it is present, set the correct permission on the binary file..."
-hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && setenforce -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
+hash getenforce 2>/dev/null && getenforce | grep "Enforcing" >/dev/null && chcon -t bin_t ${HOMEBREW_FOLDER}/services/PluginLoader
 
 echo $VERSION > ${HOMEBREW_FOLDER}/services/.loader.version
 


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This change detects if SELinux is present and if it is set the corresponding bin_t permission on the binary.
