### PR TITLE
Call plugin unload function after stopping event loop

### DIFF
--- a/backend/src/plugin.py
+++ b/backend/src/plugin.py
@@ -118,11 +118,11 @@ class PluginWrapper:
 
         if "stop" in data:
             self.log.info("Calling Loader unload function.")
-            await self._unload()
             get_event_loop().stop()
             while get_event_loop().is_running():
                 await sleep(0)
             get_event_loop().close()
+            await self._unload()
             raise Exception("Closing message listener")
 
         # TODO there is definitely a better way to type this


### PR DESCRIPTION
This can prevent race conditions where unload is clearing data but main is still working with it

Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

During the unload long-running code is still active causing possible race conditions when unloads cleans up data which main was referencing.

## Example Plugin
```py
class Plugin:
    data = []

    async def _main(self):
        while True:
            self.data.append(len(self.data))
            decky_plugin.logger.info(self.data)
            await asyncio.sleep(0.1)

    async def _unload(self):
        self.data = None

```

