### PR TITLE
Check if Linux service is running before trying to start or stop it

### DIFF
--- a/backend/src/localplatformlinux.py
+++ b/backend/src/localplatformlinux.py
@@ -125,11 +125,19 @@ async def service_restart(service_name : str) -> bool:
     return res.returncode == 0
 
 async def service_stop(service_name : str) -> bool:
+    if not await service_active(service_name):
+        # Service isn't running. pretend we stopped it
+        return True
+
     cmd = ["systemctl", "stop", service_name]
     res = run(cmd, stdout=PIPE, stderr=STDOUT)
     return res.returncode == 0
 
 async def service_start(service_name : str) -> bool:
+    if await service_active(service_name):
+        # Service is running. pretend we started it
+        return True
+
     cmd = ["systemctl", "start", service_name]
     res = run(cmd, stdout=PIPE, stderr=STDOUT)
     return res.returncode == 0


### PR DESCRIPTION
this prevents needless prompts opening up

Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Verifies a service is active before trying to start or stop it.

