### PR TITLE
replace platform chmod with os.chmod

### DIFF
--- a/backend/src/localplatformlinux.py
+++ b/backend/src/localplatformlinux.py
@@ -58,8 +58,22 @@ def chown(path : str,  user : UserType = UserType.HOST_USER, recursive : bool = 
 def chmod(path : str, permissions : int, recursive : bool = True) -> bool:
     if _get_effective_user_id() != 0:
         return True
-    result = call(["chmod", "-R", str(permissions), path] if recursive else ["chmod", str(permissions), path])
-    return result == 0
+
+    try:
+        octal_permissions = int(str(permissions), 8)
+
+        if recursive:
+            for root, dirs, files in os.walk(path):  
+                for d in dirs:  
+                    os.chmod(os.path.join(root, d), octal_permissions)
+                for d in files:
+                    os.chmod(os.path.join(root, d), octal_permissions)
+
+        os.chmod(path, octal_permissions)
+    except:
+        return False
+
+    return True
 
 def folder_owner(path : str) -> UserType|None:
     user_owner = _get_user_owner(path)


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Replaces platform specific chmod implementation with os.chmod
os.chmod is already compatible with Linux and Windows and is better at achieving the intended behavior on Windows than a noop.

Also gets rid of potential complicates with unique chmod implementations
