### PR TITLE
Use python executable directly instead of guessing

### DIFF
--- a/backend/helpers.py
+++ b/backend/helpers.py
@@ -65,7 +65,7 @@ def get_system_pythonpaths() -> list[str]:
         extra_args["env"] = {}
 
     try:
-        proc = subprocess.run(["python3" if localplatform.ON_LINUX else "python", "-c", "import sys; print('\\n'.join(x for x in sys.path if x))"],
+        proc = subprocess.run([sys.executable or "python", "-c", "import sys; print('\\n'.join(x for x in sys.path if x))"],
                               capture_output=True, **extra_args)
         return [x.strip() for x in proc.stdout.decode().strip().split("\n")]
     except Exception as e:


### PR DESCRIPTION
In the very unlikely case that no executable was found this will fall back onto "python"

Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Instead of blindly guessing the executable just use the currently interpreter executable with a fallback to plain "python"
