### PR TITLE
import decky_plugin during plugin loading and set it up as module

### DIFF
--- a/backend/src/plugin.py
+++ b/backend/src/plugin.py
@@ -84,6 +84,13 @@ class PluginWrapper:
             for key in keys:
                 sysmodules[key] = sysmodules["src"].__dict__[key]
 
+            # add decky_plugin as module ahead of time
+            plugin_file = path.join(path.dirname(__file__), "..", "plugin", "decky_plugin.py")
+            spec = spec_from_file_location("decky_plugin", plugin_file)
+            decky_plugin = module_from_spec(spec)
+            sysmodules["decky_plugin"] = decky_plugin
+            spec.loader.exec_module(decky_plugin)
+
             spec = spec_from_file_location("_", self.file)
             assert spec is not None
             module = module_from_spec(spec)


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
  - This was not tested against the PyInstaller output
- [ ] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Currently the plugin logic relies on decky_plugin.py being on the path, this PR makes it so that decky_plugin is loaded directly and put into the sys modules ready to be used.

Tested against 2 copies of the plugin template with prints added to verify that the imported instance desky_plugin is indeed different.

Had to import from an absolute path because relative imports can only be done in a package

