### PR TITLE
Add sorting by date to the plugin store

### DIFF
--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -8,7 +8,7 @@ import {
   TextField,
   findModule,
 } from 'decky-frontend-lib';
-import { FC, useEffect, useMemo, useState } from 'react';
+import { FC, useEffect, useMemo, useState, Dispatch, SetStateAction } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import logo from '../../../assets/plugin_store.png';
@@ -61,7 +61,7 @@ const StorePage: FC<{}> = () => {
   );
 };
 
-const BrowseTab: FC<{ children: { setPluginCount: setPluginCount } }> = (data) => {
+const BrowseTab: FC<{ children: { setPluginCount: Dispatch<SetStateAction<Number>> } }> = (data) => {
 
   const { t } = useTranslation();
 
@@ -79,29 +79,30 @@ const BrowseTab: FC<{ children: { setPluginCount: setPluginCount } }> = (data) =
   const [selectedSort, setSort] = useState<number>(dropdownSortOptions[0].data);
   // const [selectedFilter, setFilter] = useState<number>(filterOptions[0].data);
   const [searchFieldValue, setSearchValue] = useState<string>('');
-  const [data, setData] = useState<StorePlugin[] | null>(null);
+  const [pluginList, setPluginList] = useState<StorePlugin[] | null>(null);
   const [isTesting, setIsTesting] = useState<boolean>(false);
 
   useEffect(() => {
     (async () => {
-      sort, direction = null, null
+      let sort = null
+      let direction = null
       switch (selectedSort) {
-        case 1: direction=SortDirections.ascending;sort=SortOptions.name
+        case 1: direction=SortDirections.ascending; sort=SortOptions.name
         case 2: direction=SortDirections.descending;sort=SortOptions.name
-        case 3: direction=SortDirections.ascending;sort=SortOptions.date
+        case 3: direction=SortDirections.ascending; sort=SortOptions.date
         case 4: direction=SortDirections.descending;sort=SortOptions.date
       }
       const res = await getPluginList(sort, direction);
       logger.log('got data!', res);
-      setData(res);
-      setPluginCount(res.length)
+      setPluginList(res);
+      data.children.setPluginCount(res.length)
       const storeRes = await getStore();
       logger.log(`store is ${storeRes}, isTesting is ${storeRes === Store.Testing}`);
       setIsTesting(storeRes === Store.Testing);
     })();
   }, []);
 
-  return !data ? (
+  return !pluginList ? (
     <div style={{ height: '100%' }}>
       <SteamSpinner />
     </div>
@@ -222,7 +223,7 @@ const BrowseTab: FC<{ children: { setPluginCount: setPluginCount } }> = (data) =
         </div>
       )}
       <div>
-        {data
+        {pluginList
           .filter((plugin: StorePlugin) => {
             return (
               plugin.name.toLowerCase().includes(searchFieldValue.toLowerCase()) ||

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -61,7 +61,7 @@ const StorePage: FC<{}> = () => {
   );
 };
 
-const BrowseTab: FC<{ children: { setPluginCount: Dispatch<SetStateAction<Number>> } }> = (data) => {
+const BrowseTab: FC<{ children: { setPluginCount: Dispatch<SetStateAction<Number | null>> } }> = (data) => {
 
   const { t } = useTranslation();
 

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -87,15 +87,20 @@ const BrowseTab: FC<{ children: { setPluginCount: Dispatch<SetStateAction<Number
       let sort = null
       let direction = null
       switch (selectedSort) {
-        case 1: direction=SortDirections.ascending; sort=SortOptions.name
-        case 2: direction=SortDirections.descending;sort=SortOptions.name
-        case 3: direction=SortDirections.ascending; sort=SortOptions.date
-        case 4: direction=SortDirections.descending;sort=SortOptions.date
+        case 1: direction=SortDirections.ascending;  sort=SortOptions.name
+        case 2: direction=SortDirections.descending; sort=SortOptions.name
+        case 3: direction=SortDirections.ascending;  sort=SortOptions.date
+        case 4: direction=SortDirections.descending; sort=SortOptions.date
       }
       const res = await getPluginList(sort, direction);
       logger.log('got data!', res);
       setPluginList(res);
       data.children.setPluginCount(res.length)
+    })();
+  }, [selectedSort]);
+
+  useEffect(() => {
+    (async () => {
       const storeRes = await getStore();
       logger.log(`store is ${storeRes}, isTesting is ${storeRes === Store.Testing}`);
       setIsTesting(storeRes === Store.Testing);

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -232,10 +232,10 @@ const BrowseTab: FC<{ children: { setPluginCount: Dispatch<SetStateAction<Number
               plugin.tags.some((tag: string) => tag.toLowerCase().includes(searchFieldValue.toLowerCase()))
             );
           })
-          .sort((a, b) => {
-            if (selectedSort % 2 === 1) return a.name.localeCompare(b.name);
-            else return b.name.localeCompare(a.name);
-          })
+          //.sort((a, b) => {
+          //  if (selectedSort % 2 === 1) return a.name.localeCompare(b.name);
+          //  else return b.name.localeCompare(a.name);
+          //})
           .map((plugin: StorePlugin) => (
             <PluginCard plugin={plugin} />
           ))}

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -51,11 +51,11 @@ export async function getPluginList(sort_by : SortOptions | null=null, sort_dire
   let store = await getSetting<Store>('store', Store.Default);
   let customURL = await getSetting<string>('store-url', 'https://plugins.deckbrew.xyz/plugins');
 
-  let query = URLSearchParams()
+  let query = new URLSearchParams()
   sort_by && query.set("sort_by",sort_by)
   sort_direction && query.set("sort_direction", sort_direction)
   query = "?"+query
-  
+
   let storeURL;
   if (!store) {
     console.log('Could not get a default store, using Default.');

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -54,7 +54,7 @@ export async function getPluginList(sort_by : SortOptions | null=null, sort_dire
   let query = new URLSearchParams()
   sort_by && query.set("sort_by",sort_by)
   sort_direction && query.set("sort_direction", sort_direction)
-  query = "?"+query
+  query = "?"+String(query)
 
   let storeURL;
   if (!store) {

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -7,6 +7,16 @@ export enum Store {
   Custom,
 }
 
+export enum SortOptions {
+  name = "name",
+  date = "date"
+}
+
+export enum SortDirections {
+  ascending = "asc",
+  descending = "desc"
+}
+
 export interface StorePluginVersion {
   name: string;
   hash: string;
@@ -36,10 +46,16 @@ export async function getStore(): Promise<Store> {
   return await getSetting<Store>('store', Store.Default);
 }
 
-export async function getPluginList(): Promise<StorePlugin[]> {
+export async function getPluginList(sort_by : SortOptions | null=null, sort_direction: SortDirections | null=null): Promise<StorePlugin[]> {
   let version = await window.DeckyPluginLoader.updateVersion();
   let store = await getSetting<Store>('store', Store.Default);
   let customURL = await getSetting<string>('store-url', 'https://plugins.deckbrew.xyz/plugins');
+
+  let query = URLSearchParams()
+  sort_by && query.set("sort_by",sort_by)
+  sort_direction && query.set("sort_direction", sort_direction)
+  query = "?"+query
+  
   let storeURL;
   if (!store) {
     console.log('Could not get a default store, using Default.');
@@ -66,7 +82,7 @@ export async function getPluginList(): Promise<StorePlugin[]> {
         storeURL = 'https://plugins.deckbrew.xyz/plugins';
         break;
     }
-    return fetch(storeURL, {
+    return fetch(storeURL+query, {
       method: 'GET',
       headers: {
         'X-Decky-Version': version.current,


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC -- sort of
- [ ] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #419

(This is currently waiting on https://github.com/SteamDeckHomebrew/decky-plugin-store/pull/51 so it actually works instead of just breaking sorting)
Adds two new options to the plugin store's sort box, date ascending and date descending.
