### PR TITLE
Count the number of installs for each plugin

### DIFF
--- a/backend/browser.py
+++ b/backend/browser.py
@@ -173,10 +173,11 @@ class PluginBrowser:
                 case 1: storeUrl = "https://testing.deckbrew.xyz" # testing
                 case 2: storeUrl = self.settings.getSetting("store-url", "https://plugins.deckbrew.xyz")  # custom TODO: this won't work properly, maybe change the way the url is handled in the frontend to not include the /plugins bit
                 case _: storeUrl = "https://plugins.deckbrew.xyz"
-            logger.info(f"Incrementing {name} from URL {storeUrl}")
+            logger.info(f"Incrementing installs for {name} from URL {storeUrl} (version {hash})")
             async with ClientSession() as client:
-                await client.post(storeUrl+"/increment", ssl=get_ssl_context(), data={"plugin_name":name,"isUpdate":str(isInstalled)})
-                # todo: have error handling here? it doesn't really matter if it succeeds or not to be honest.
+                res = await client.post(storeUrl+"/increment/{hash}?isUpdate={isInstalled}", ssl=get_ssl_context())
+                if res.status != 200:
+                    logger.error(f"Server did not accept install count increment request. code: {res.status}")
 
         # Check to make sure we got the file
         if res_zip is None:

--- a/backend/browser.py
+++ b/backend/browser.py
@@ -175,7 +175,7 @@ class PluginBrowser:
                 case _: storeUrl = "https://plugins.deckbrew.xyz"
             logger.info(f"Incrementing installs for {name} from URL {storeUrl} (version {hash})")
             async with ClientSession() as client:
-                res = await client.post(storeUrl+"/increment/{hash}?isUpdate={isInstalled}", ssl=get_ssl_context())
+                res = await client.post(storeUrl+f"/increment/{version}/{hash}?isUpdate={isInstalled}", ssl=get_ssl_context())
                 if res.status != 200:
                     logger.error(f"Server did not accept install count increment request. code: {res.status}")
 

--- a/backend/browser.py
+++ b/backend/browser.py
@@ -167,6 +167,17 @@ class PluginBrowser:
                 else:
                     logger.fatal(f"Could not fetch from URL. {await res.text()}")
 
+            storeUrl = ""
+            match self.settings.getSetting("store", 0):
+                case 0: storeUrl = "https://plugins.deckbrew.xyz" # default
+                case 1: storeUrl = "https://testing.deckbrew.xyz" # testing
+                case 2: storeUrl = self.settings.getSetting("store-url", "https://plugins.deckbrew.xyz")  # custom TODO: this won't work properly, maybe change the way the url is handled in the frontend to not include the /plugins bit
+                case _: storeUrl = "https://plugins.deckbrew.xyz"
+            logger.info(f"Incrementing {name} from URL {storeUrl}")
+            async with ClientSession() as client:
+                await client.post(storeUrl+"/increment", ssl=get_ssl_context(), data={"plugin_name":name,"isUpdate":str(isInstalled)})
+                # todo: have error handling here? it doesn't really matter if it succeeds or not to be honest.
+
         # Check to make sure we got the file
         if res_zip is None:
             logger.fatal(f"Could not fetch {artifact}")

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -38,8 +38,8 @@ export async function getStore(): Promise<Store> {
 
 export async function getPluginList(): Promise<StorePlugin[]> {
   let version = await window.DeckyPluginLoader.updateVersion();
-  let store = await getSetting<Store>('store', null);
-  let customURL = await getSetting<string>('store-url', 'https://plugins.deckbrew.xyz/plugins');
+  let store = await getSetting<Store | null>('store', null);
+  let customURL = await getSetting<string>('store-url', 'https://plugins.deckbrew.xyz');
   let storeURL;
   if (store === null) {
     console.log('Could not get store, using Default.');
@@ -48,20 +48,20 @@ export async function getPluginList(): Promise<StorePlugin[]> {
   }
   switch (+store) {
     case Store.Default:
-      storeURL = 'https://plugins.deckbrew.xyz/plugins';
+      storeURL = 'https://plugins.deckbrew.xyz';
       break;
     case Store.Testing:
-      storeURL = 'https://testing.deckbrew.xyz/plugins';
+      storeURL = 'https://testing.deckbrew.xyz';
       break;
     case Store.Custom:
       storeURL = customURL;
       break;
     default:
       console.error('Somehow you ended up without a standard URL, using the default URL.');
-      storeURL = 'https://plugins.deckbrew.xyz/plugins';
+      storeURL = 'https://plugins.deckbrew.xyz';
       break;
   }
-  return fetch(storeURL, {
+  return fetch(storeURL+"/plugins", {
     method: 'GET',
     headers: {
       'X-Decky-Version': version.current,


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This is waiting for https://github.com/SteamDeckHomebrew/decky-plugin-store/pull/52 to be on the main store.
Whenever a plugin is installed the loader will send a request to an /increment endpoint on the plugin server so it can increment the number of downloads/updates by one. This will be used for sorting by popularity at some point in the future, once there's enough downloads recorded to make the sort meaningful.