### PR TITLE
Count the number of installs for each plugin

### DIFF
--- a/backend/src/browser.py
+++ b/backend/src/browser.py
@@ -188,10 +188,10 @@ class PluginBrowser:
 
             storeUrl = ""
             match self.settings.getSetting("store", 0):
-                case 0: storeUrl = "https://plugins.deckbrew.xyz" # default
-                case 1: storeUrl = "https://testing.deckbrew.xyz" # testing
-                case 2: storeUrl = self.settings.getSetting("store-url", "https://plugins.deckbrew.xyz")  # custom
-                case _: storeUrl = "https://plugins.deckbrew.xyz"
+                case 0: storeUrl = "https://plugins.deckbrew.xyz/plugins" # default
+                case 1: storeUrl = "https://testing.deckbrew.xyz/plugins" # testing
+                case 2: storeUrl = self.settings.getSetting("store-url", "https://plugins.deckbrew.xyz/plugins")  # custom
+                case _: storeUrl = "https://plugins.deckbrew.xyz/plugins"
             logger.info(f"Incrementing installs for {name} from URL {storeUrl} (version {version})")
             async with ClientSession() as client:
                 res = await client.post(storeUrl+f"/{name}/versions/{version}/increment?isUpdate={isInstalled}", ssl=get_ssl_context())

--- a/backend/src/browser.py
+++ b/backend/src/browser.py
@@ -186,6 +186,18 @@ class PluginBrowser:
                 else:
                     logger.fatal(f"Could not fetch from URL. {await res.text()}")
 
+            storeUrl = ""
+            match self.settings.getSetting("store", 0):
+                case 0: storeUrl = "https://plugins.deckbrew.xyz" # default
+                case 1: storeUrl = "https://testing.deckbrew.xyz" # testing
+                case 2: storeUrl = self.settings.getSetting("store-url", "https://plugins.deckbrew.xyz")  # custom
+                case _: storeUrl = "https://plugins.deckbrew.xyz"
+            logger.info(f"Incrementing installs for {name} from URL {storeUrl} (version {version})")
+            async with ClientSession() as client:
+                res = await client.post(storeUrl+f"/{name}/versions/{version}/increment?isUpdate={isInstalled}", ssl=get_ssl_context())
+                if res.status != 200:
+                    logger.error(f"Server did not accept install count increment request. code: {res.status}")
+
         # Check to make sure we got the file
         if res_zip is None:
             logger.fatal(f"Could not fetch {artifact}")


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This will currently only work with the testing store, as the changes are not yet on the main store.
Whenever a plugin is installed the loader will send a request to an /increment endpoint on the plugin server so it can increment the number of downloads/updates by one. This will be used for sorting by popularity at some point in the future, once there's enough downloads recorded to make the sort meaningful.
