### PR TITLE
fix: Fix on Chromium 109 beta

### DIFF
--- a/backend/src/injector.py
+++ b/backend/src/injector.py
@@ -412,7 +412,7 @@ async def get_tab_lambda(test: Callable[[Tab], bool]) -> Tab:
 
 SHARED_CTX_NAMES = ["SharedJSContext", "Steam Shared Context presented by Valve™", "Steam", "SP"]
 CLOSEABLE_URLS = ["about:blank", "data:text/html,%3Cbody%3E%3C%2Fbody%3E"] # Closing anything other than these *really* likes to crash Steam
-DO_NOT_CLOSE_URL = "Valve Steam Gamepad/default" # Steam Big Picture Mode tab
+DO_NOT_CLOSE_URLS = ["Valve Steam Gamepad/default", "Valve%20Steam%20Gamepad/default"] # Steam Big Picture Mode tab
 
 def tab_is_gamepadui(t: Tab) -> bool:
     return "https://steamloopback.host/routes/" in t.url and t.title in SHARED_CTX_NAMES
@@ -432,7 +432,7 @@ async def inject_to_tab(tab_name: str, js: str, run_async: bool = False):
 async def close_old_tabs():
     tabs = await get_tabs()
     for t in tabs:
-        if not t.title or (t.title not in SHARED_CTX_NAMES and any(url in t.url for url in CLOSEABLE_URLS) and DO_NOT_CLOSE_URL not in t.url):
+        if not t.title or (t.title not in SHARED_CTX_NAMES and any(url in t.url for url in CLOSEABLE_URLS) and not any(url in t.url for url in DO_NOT_CLOSE_URLS)):
             logger.debug("Closing tab: " + getattr(t, "title", "Untitled"))
             await t.close()
             await sleep(0.5)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,7 +44,7 @@
     }
   },
   "dependencies": {
-    "decky-frontend-lib": "3.24.1",
+    "decky-frontend-lib": "3.24.2",
     "filesize": "^10.0.7",
     "i18next": "^23.2.1",
     "i18next-http-backend": "^2.2.1",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -6,8 +6,8 @@ settings:
 
 dependencies:
   decky-frontend-lib:
-    specifier: 3.24.1
-    version: 3.24.1
+    specifier: 3.24.2
+    version: 3.24.2
   filesize:
     specifier: ^10.0.7
     version: 10.0.7
@@ -1482,8 +1482,8 @@ packages:
     dependencies:
       ms: 2.1.2
 
-  /decky-frontend-lib@3.24.1:
-    resolution: {integrity: sha512-VGxLTPetxx/pQVC+t8odTHrwQAh7uy4bO2Od2gGWSTfmUUoxtAcEtiXGyE9mKsoD6t7QNHrGvgXn78sf2i/IeQ==}
+  /decky-frontend-lib@3.24.2:
+    resolution: {integrity: sha512-G6AEV/PTdOaw2AoGGs+tpEWIPhVODzM8XWAJcHwXVpCnAGH+qUhHZH/Mz56ZxYcbVdN3m6FRAQ2eHSUIEY9TjA==}
     dev: false
 
   /decode-named-character-reference@1.0.2:


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

On January 18th, a new steam client beta was released bumping CEF to chromium 109, this also changed some tab names, as well as breaking the Navigation object on Decky Frontend Lib.

This PR fixes the tab names (courtesy of @suchmememanyskill), as well as bumping DFL to the new fixed verison.


I have tested both commits on both an LCD Deck running SteamOS Stable and an OLED Deck running SteamOS beta, everything works again. Plugins using global DFL shouldn't have to update anything.
