### PR TITLE
Get plugin name for development ZIP during installation

### DIFF
--- a/backend/src/browser.py
+++ b/backend/src/browser.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from io import BytesIO
 from logging import getLogger
 from os import R_OK, W_OK, path, listdir, access, mkdir
+from re import sub
 from shutil import rmtree
 from time import time
 from zipfile import ZipFile
@@ -162,12 +163,6 @@ class PluginBrowser:
         current_plugin_order = self.settings.getSetting("pluginOrder")[:]
         if self.loader.watcher:
             self.loader.watcher.disabled = True
-        try:
-            pluginFolderPath = self.find_plugin_folder(name)
-            if pluginFolderPath:
-                isInstalled = True
-        except:
-            logger.error(f"Failed to determine if {name} is already installed, continuing anyway.")
 
         # Check if the file is a local file or a URL
         if artifact.startswith("file://"):
@@ -197,6 +192,28 @@ class PluginBrowser:
                 res = await client.post(storeUrl+f"/{name}/versions/{version}/increment?isUpdate={isInstalled}", ssl=get_ssl_context())
                 if res.status != 200:
                     logger.error(f"Server did not accept install count increment request. code: {res.status}")
+
+        if res_zip and version == "dev":
+            with ZipFile(res_zip) as plugin_zip:
+                plugin_json_list = [file for file in plugin_zip.namelist() if file.endswith("/plugin.json") and file.count("/") == 1]
+
+                if len(plugin_json_list) == 0:
+                    logger.fatal("No plugin.json found in plugin ZIP")
+                    return
+
+                elif len(plugin_json_list) > 1:
+                    logger.fatal("Multiple plugin.json found in plugin ZIP")
+                    return
+
+                else:
+                    name = sub(r"/.+$", "", plugin_json_list[0])
+
+        try:
+            pluginFolderPath = self.find_plugin_folder(name)
+            if pluginFolderPath:
+                isInstalled = True
+        except:
+            logger.error(f"Failed to determine if {name} is already installed, continuing anyway.")
 
         # Check to make sure we got the file
         if res_zip is None:

--- a/frontend/src/toaster.tsx
+++ b/frontend/src/toaster.tsx
@@ -56,7 +56,8 @@ class Toaster extends Logger {
       if (
         currentNode?.memoizedProps?.className?.startsWith?.('gamepadtoasts_GamepadToastPlaceholder') ||
         currentNode?.memoizedProps?.className?.startsWith?.('toastmanager_ToastPlaceholder') ||
-        currentNode?.memoizedProps?.className?.startsWith?.('toastmanager_ToastPopup')
+        currentNode?.memoizedProps?.className?.startsWith?.('toastmanager_ToastPopup') ||
+        currentNode?.memoizedProps?.className?.startsWith?.('gamepadtoasts_GamepadToastPopup')
       ) {
         this.log(`Toaster root was found in ${iters} recursion cycles`);
         return currentNode;


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Currently the development plugin installation from ZIP / URL is broken partially, due to relying on ZIP name as the plugin name. This commit fixes the issue, by parsing the plugin name from the folder containing `plugin.json` from the ZIP. I tested this on my Steam Deck OLED and can confirm it to fix the issue. I installed a ZIP which previously failed installation and it now works without issue with this commit.

## Related comments on issue

https://github.com/SteamDeckHomebrew/decky-loader/issues/527#issuecomment-1908169324

https://github.com/SteamDeckHomebrew/decky-loader/issues/527#issuecomment-1908947062

This fixes issue: #527
