### PR TITLE
Revert "Call plugin unload function after stopping event loop"

### DIFF
--- a/backend/src/plugin.py
+++ b/backend/src/plugin.py
@@ -118,11 +118,11 @@ class PluginWrapper:
 
         if "stop" in data:
             self.log.info("Calling Loader unload function.")
+            await self._unload()
             get_event_loop().stop()
             while get_event_loop().is_running():
                 await sleep(0)
             get_event_loop().close()
-            await self._unload()
             raise Exception("Closing message listener")
 
         # TODO there is definitely a better way to type this


### PR DESCRIPTION
Functions don't appear to run after the event loop closes, so the unload function is never actually run.