### PR TITLE
fix(filepicker_ls): use case insensitive matching for file exts

### DIFF
--- a/backend/src/utilities.py
+++ b/backend/src/utilities.py
@@ -238,7 +238,7 @@ class Utilities:
                 elif include_files:
                     # Handle requested extensions if present
                     if len(include_ext) == 0 or 'all_files' in include_ext \
-                        or splitext(file.name)[1].lstrip('.') in include_ext:
+                        or splitext(file.name)[1].lstrip('.').upper() in (ext.upper() for ext in include_ext):
                         if (is_hidden and include_hidden) or not is_hidden:
                             files.append({"file": file, "filest": filest, "is_dir": False})
         # Filter logic


### PR DESCRIPTION
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description
Adds case insensitive matching to fix files not showing when using `validFileExtensions` in `openFilePickerV2()` .
Example:
```tsx
<FilePicker
    validFileExtensions={['.png']} // this would match ".png" but not ".PNG"
/>
```