### PR TITLE
Added code for making it so the user can rename plugins.

### DIFF
--- a/backend/src/plugin.py
+++ b/backend/src/plugin.py
@@ -183,3 +183,30 @@ class PluginWrapper:
                 if not res["success"]:
                     raise Exception(res["res"])
                 return res["res"]
+    
+    # rename plugin
+    async def rename(self, new_name):
+        old_path = os.path.join(self.plugin_path, self.plugin_directory)
+        new_path = os.path.join(self.plugin_path, new_name)
+        if os.path.exists(new_path):
+            raise Exception("A plugin with the new name already exists.")
+        
+        self.update_configuration(new_name)
+
+        os.rename(old_path, new_path)
+
+        self.name = new_name
+        self.plugin_directory = new_name
+
+        self.log.info(f"Plugin renamed from {self.plugin_directory} to {new_name}")
+
+    def update_configuration(self, new_name):
+        config_path = os.path.join(self.plugin_path, self.plugin_directory, 'config.json')
+        if os.path.exists(config_path):
+            with open(config_path, 'r+') as file:
+                config = json.load(file)
+                config['name'] = new_name
+                file.seek(0)
+                json.dump(config, file, indent=4)
+                file.truncate()
+    # end rename plugin

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -2,6 +2,7 @@ import {
   DialogBody,
   DialogButton,
   DialogControlsSection,
+  DialogInput,
   GamepadEvent,
   Menu,
   MenuItem,
@@ -46,6 +47,7 @@ type PluginTableData = PluginData & {
 
 function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }) {
   const { t } = useTranslation();
+  const DialogBody = useDialog();
 
   // nothing to display without this data...
   if (!props.entry.data) {
@@ -98,6 +100,8 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
         ) : (
           isDeveloper && <MenuItem onSelected={onFreeze}>{t('PluginListIndex.freeze')}</MenuItem>
         )}
+        {/* Rename plugin button */}
+        <MenuItem onSelected={() => promptRename(name)}>{t('PluginListIndex.rename')}</MenuItem>
       </Menu>,
       e.currentTarget ?? window,
     );
@@ -241,3 +245,47 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
     </DialogBody>
   );
 }
+
+// Rename plugin functionality
+const handleRename = async (originalName: string, newName: string) => {
+  try {
+      const response = await fetch(`http://127.0.0.1:1337/plugins/${originalName}/rename`, {
+          method: 'POST',
+          headers: {
+              'Content-Type': 'application/json',
+              'Authentication': window.deckyAuthToken,
+          },
+          body: JSON.stringify({ newName }),
+      });
+      if (!response.ok) {
+          throw new Error('Failed to rename plugin');
+      }
+      console.log('Plugin renamed successfully');
+  } catch (error) {
+      console.error('Error renaming plugin:', error);
+  }
+};
+
+const promptRename = (originalName: string) => {
+  DialogBody.open(
+    <DialogBody>
+      <DialogBody title={t('PluginListIndex.rename_plugin')}>
+        <DialogInput
+          initialValue={originalName}
+          label={t('PluginListIndex.enter_new_name')}
+          onConfirm={(newName) => {
+            handleRename(originalName, newName);
+            DialogBody.close();
+          }}
+          onCancel={() => DialogBody.close()}
+        />
+      </DialogBody>
+      <DialogControlsSection>
+        <DialogButton label={t('common.ok')} onClick={() => {/* Confirm change of name */}} />
+        <DialogButton label={t('common.cancel')} onClick={() => DialogBody.close()} />
+      </DialogControlsSection>
+    </DialogBody>
+  );
+};
+// End of Rename plugin functionality
+


### PR DESCRIPTION
Please tick as appropriate:
- [ x] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [ x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description
The intention is to make it so the user is able to rename plugins.  To do this an additional setting button was added in the settings \ plugins \ ...  context menu named "Rename".  This button should bring up a dialog with a text box, a enter button and a cancel button.  once the user has input the name they wish for the plugin they can push enter to rename it or cancel to exit out with out renaming it.

The files changed were:
backend\src\main.py
backend\src\plugin.py
frontend\src\components\settings\pages\plugin_list\index.tsx

This fixes issue: #629

Please provide a clear and concise description of what the new feature is. If appropriate, include screenshots or videos.
 I still have some testing to do the the code to fix some error.
