### PR TITLE
Sims/pyinstaller misuse fix

### DIFF
--- a/backend/decky_loader/helpers.py
+++ b/backend/decky_loader/helpers.py
@@ -90,7 +90,11 @@ def get_system_pythonpaths() -> list[str]:
         proc = subprocess.run(["python3" if localplatform.ON_LINUX else "python", "-c", "import sys; print('\\n'.join(x for x in sys.path if x))"],
         # TODO make this less insane
                               capture_output=True, user=localplatform.localplatform._get_user_id() if localplatform.ON_LINUX else None, env={} if localplatform.ON_LINUX else None) # pyright: ignore [reportPrivateUsage]
-        return [x.strip() for x in proc.stdout.decode().strip().split("\n")]
+        
+        proc.check_returncode()
+
+        versions = [x.strip() for x in proc.stdout.decode().strip().split("\n")]
+        return [x for x in versions if x and not x.isspace()]
     except Exception as e:
         logger.warn(f"Failed to execute get_system_pythonpaths(): {str(e)}")
         return []

--- a/backend/decky_loader/main.py
+++ b/backend/decky_loader/main.py
@@ -7,14 +7,16 @@ from .localplatform.localplatform import (chmod, chown, service_stop, service_st
                             get_privileged_path, restart_webhelper)
 if hasattr(sys, '_MEIPASS'):
     chmod(sys._MEIPASS, 755) # type: ignore
+    
 # Full imports
+import multiprocessing
+multiprocessing.freeze_support()
 from asyncio import AbstractEventLoop, CancelledError, Task, all_tasks, current_task, gather, new_event_loop, set_event_loop, sleep
 from logging import basicConfig, getLogger
 from os import path
 from traceback import format_exc
-import multiprocessing
-
 import aiohttp_cors # pyright: ignore [reportMissingTypeStubs]
+
 # Partial imports
 from aiohttp import client_exceptions
 from aiohttp.web import Application, Response, Request, get, run_app, static # pyright: ignore [reportUnknownVariableType]
@@ -223,9 +225,6 @@ def main():
         # Fix windows/flask not recognising that .js means 'application/javascript'
         import mimetypes
         mimetypes.add_type('application/javascript', '.js')
-
-        # Required for multiprocessing support in frozen files
-        multiprocessing.freeze_support()
     else:
         if get_effective_user_id() != 0:
             logger.warning(f"decky is running as an unprivileged user, this is not officially supported and may cause issues")

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -13,7 +13,7 @@ from .messages import SocketResponseDict, SocketMessageType
 from ..localplatform.localsocket import LocalSocket
 from ..localplatform.localplatform import setgid, setuid, get_username, get_home_path
 from ..enums import UserType
-from .. import helpers, settings
+from .. import helpers, settings, injector # pyright: ignore [reportUnusedImport]
 
 from typing import List, TypeVar, Any
 

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -13,7 +13,7 @@ from .messages import SocketResponseDict, SocketMessageType
 from ..localplatform.localsocket import LocalSocket
 from ..localplatform.localplatform import setgid, setuid, get_username, get_home_path
 from ..enums import UserType
-from .. import helpers
+from .. import helpers, settings
 
 from typing import List, TypeVar, Any
 
@@ -123,7 +123,7 @@ class SandboxedPlugin:
             get_event_loop().create_task(socket.setup_server())
         except:
             self.log.error("Failed to start " + self.name + "!\n" + format_exc())
-            exit(0)
+            sys.exit(0)
         try:
             get_event_loop().run_forever()
         except SystemExit:


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
    - Tested on Windows and Steam Deck (preview)
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

# Description
We incorrectly use pyinstaller in some parts of decky. This PR fixes that.
For more details, see [this discussion](https://github.com/orgs/pyinstaller/discussions/8651)

This originally was to fix windows again, but just because it worked on linux doesn't mean these misuses shouldn't be fixed.

Note: This PR brings a massive breaking change. We handle imports properly now, which means decky plugins **can no longer** use decky internals in their own application. (They still kind of can, but only what is explicitly imported into sandboxed_plugin.py).

Imo it's preferrable that plugins do not use decky internals in their own plugins. I think we should reconsider this. 
