### PR TITLE
fix: fetchNoCors and http_request data handling

### DIFF
--- a/backend/decky_loader/utilities.py
+++ b/backend/decky_loader/utilities.py
@@ -141,10 +141,10 @@ class Utilities:
 
     # Loosely based on https://gist.github.com/mosquito/4dbfacd51e751827cda7ec9761273e95#file-proxy-py
     async def http_request(self, req: Request) -> StreamResponse:
-        if req.headers.get('X-Decky-Auth', '') != helpers.get_csrf_token() and req.query.get('auth', '') != helpers.get_csrf_token():
+        if req.query['auth'] != helpers.get_csrf_token():
             return Response(text='Forbidden', status=403)
 
-        url = req.headers["X-Decky-Fetch-URL"] if "X-Decky-Fetch-URL" in req.headers else unquote(req.query.get('fetch_url', ''))
+        url = unquote(req.query['fetch_url'])
         self.logger.info(f"Preparing {req.method} request to {url}")
 
         headers = dict(req.headers)

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -536,17 +536,13 @@ class PluginLoader extends Logger {
       }
       return prefixedInitHeaders;
     };
-    const headers: { [name: string]: string } = {
-      ...getPrefixedHeaders(),
-      'X-Decky-Auth': deckyAuthToken,
-      'X-Decky-Fetch-URL': input,
-    };
+    const headers: { [name: string]: string } = getPrefixedHeaders();
 
     if (init?.excludedHeaders) {
       headers['X-Decky-Fetch-Excluded-Headers'] = init.excludedHeaders.join(', ');
     }
 
-    return fetch('http://127.0.0.1:1337/fetch', {
+    return fetch(this.getExternalResourceURL(input), {
       ...restOfInit,
       credentials: 'include',
       headers,

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -528,8 +528,16 @@ class PluginLoader extends Logger {
 
   // Same syntax as fetch but only supports the url-based syntax and an object for headers since it's the most common usage pattern
   fetchNoCors(input: string, init?: DeckyRequestInit | undefined): Promise<Response> {
+    const { headers: initHeaders = {}, ...restOfInit } = init || {};
+    const getPrefixedHeaders = () => {
+      let prefixedInitHeaders: { [name: string]: any } = {};
+      for (const [key, value] of Object.entries(initHeaders)) {
+        prefixedInitHeaders[`X-Decky-Header-${key}`] = value;
+      }
+      return prefixedInitHeaders;
+    };
     const headers: { [name: string]: string } = {
-      ...(init?.headers as { [name: string]: string }),
+      ...getPrefixedHeaders(),
       'X-Decky-Auth': deckyAuthToken,
       'X-Decky-Fetch-URL': input,
     };
@@ -539,7 +547,7 @@ class PluginLoader extends Logger {
     }
 
     return fetch('http://127.0.0.1:1337/fetch', {
-      ...init,
+      ...restOfInit,
       credentials: 'include',
       headers,
     });


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This PR solves 4 problems:
1. `fetchNoCors` does not prefix explicitly specified headers which can later be overwritten or deleted by `http_request` handler. Arguably, if the user has specified headers explicitly then they must be sent out in the end.
2. `http_handler` would automatically decompress received data, but not intended to do so. Decompressing is now delegate to JS engine.
3. `fetchNoCors` would cache the the request incorrectly under a generic `http://127.0.0.1:1337/fetch` url if the server response asks it to. Caching could be disabled completely for `fetchNoCors`, however another approach was taken - url is added as a query parameter so that the cache is associated correctly with the provided url.
4.  `http_handler` no longer has special headers for `auth` and `url`, and are now parsed from query only. Replaced the `get` methods with access operators so that the exception is thrown early on an ill-formed url to avoid confusing exceptions down the line. 

