### PR TITLE
Update plugin_loader-release.service

### DIFF
--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -4,7 +4,7 @@ Description=SteamDeck Plugin Loader
 Type=simple
 User=root
 Restart=always
-TimeoutStopSec=45
+KillSignal=SIGKILL
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services
 Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}


### PR DESCRIPTION
Please tick as appropriate:
- [*] I have tested this code on a steam deck or on a PC
- [*] My changes generate no new errors/warnings
- [*] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

For newcomers I suggest the Release version to be changed to KillSignal=SIGKILL instead of TimeoutStopSec=45.

This fixes issue: TimeoutStopSec is set to 45 seconds, and such the Deck would take 45 seconds longer to ShutDown or Restart. Replaced it with KillSignal=SIGKILL.

Please provide a clear and concise description of what the new feature is. If appropriate, include screenshots or videos.
