### PR TITLE
Work around account switching failing to open the CEF debugger socket

### DIFF
--- a/backend/decky_loader/localplatform/localplatform.py
+++ b/backend/decky_loader/localplatform/localplatform.py
@@ -37,6 +37,9 @@ def get_live_reload() -> bool:
 def get_keep_systemd_service() -> bool:
     return os.getenv("KEEP_SYSTEMD_SERVICE", "0") == "1"
 
+def get_use_cef_close_workaround() -> bool:
+    return ON_LINUX and os.getenv("USE_CEF_CLOSE_WORKAROUND", "1") == "1"
+
 def get_log_level() -> int:
     return {"CRITICAL": 50, "ERROR": 40, "WARNING": 30, "INFO": 20, "DEBUG": 10}[
         os.getenv("LOG_LEVEL", "INFO")

--- a/backend/decky_loader/localplatform/localplatformlinux.py
+++ b/backend/decky_loader/localplatform/localplatformlinux.py
@@ -258,7 +258,7 @@ async def close_cef_socket():
         logger.info(f"Closing CEF socket with PID {pid} and FD {fd}")
 
         # Use gdb to inject a close() call for the socket fd into steamwebhelper
-        gdb_ret = run(["gdb", "--nx", "-p", pid, "--batch", "--eval-command", f"call (int)close({fd})"])
+        gdb_ret = run(["gdb", "--nx", "-p", pid, "--batch", "--eval-command", f"call (int)close({fd})"], env={"LD_LIBRARY_PATH": ""})
 
         if gdb_ret.returncode != 0:
             logger.error(f"Failed to close CEF socket with gdb! return code: {str(gdb_ret.returncode)}", exc_info=True)

--- a/backend/decky_loader/localplatform/localplatformwin.py
+++ b/backend/decky_loader/localplatform/localplatformwin.py
@@ -56,3 +56,6 @@ def get_unprivileged_user() -> str:
 
 async def restart_webhelper() -> bool:
     return True # Stubbed
+
+async def close_cef_socket():
+    return # Stubbed

--- a/backend/decky_loader/utilities.py
+++ b/backend/decky_loader/utilities.py
@@ -20,9 +20,8 @@ from .browser import PluginInstallRequest, PluginInstallType
 if TYPE_CHECKING:
     from .main import PluginManager
 from .injector import inject_to_tab, get_gamepadui_tab, close_old_tabs, get_tab
-from .localplatform.localplatform import ON_WINDOWS
 from . import helpers
-from .localplatform.localplatform import service_stop, service_start, get_home_path, get_username
+from .localplatform.localplatform import ON_WINDOWS, service_stop, service_start, get_home_path, get_username, get_use_cef_close_workaround, close_cef_socket
 
 class FilePickerObj(TypedDict):
     file: Path
@@ -78,6 +77,7 @@ class Utilities:
             context.ws.add_route("utilities/get_tab_id", self.get_tab_id)
             context.ws.add_route("utilities/get_user_info", self.get_user_info)
             context.ws.add_route("utilities/http_request", self.http_request_legacy)
+            context.ws.add_route("utilities/close_cef_socket", self.close_cef_socket)
             context.ws.add_route("utilities/_call_legacy_utility", self._call_legacy_utility)
 
             context.web_app.add_routes([
@@ -286,6 +286,10 @@ class Utilities:
     async def stop_ssh(self):
         await service_stop(helpers.SSHD_UNIT)
         return True
+
+    async def close_cef_socket(self):
+        if get_use_cef_close_workaround():
+            await close_cef_socket()
 
     async def filepicker_ls(self, 
                             path: str | None = None, 

--- a/frontend/src/steamfixes/index.ts
+++ b/frontend/src/steamfixes/index.ts
@@ -1,5 +1,5 @@
 // import restartFix from './restart';
-import cefSocketFix from "./socket";
+import cefSocketFix from './socket';
 
 let fixes: Function[] = [];
 

--- a/frontend/src/steamfixes/index.ts
+++ b/frontend/src/steamfixes/index.ts
@@ -1,5 +1,6 @@
-// import reloadFix from './reload';
-import restartFix from './restart';
+// import restartFix from './restart';
+import cefSocketFix from "./socket";
+
 let fixes: Function[] = [];
 
 export function deinitSteamFixes() {
@@ -7,6 +8,6 @@ export function deinitSteamFixes() {
 }
 
 export async function initSteamFixes() {
-  // fixes.push(await reloadFix());
-  fixes.push(await restartFix());
+  fixes.push(cefSocketFix());
+  // fixes.push(await restartFix());
 }

--- a/frontend/src/steamfixes/socket.ts
+++ b/frontend/src/steamfixes/socket.ts
@@ -1,0 +1,16 @@
+import Logger from "../logger";
+
+const logger = new Logger('CEFSocketFix');
+
+const closeCEFSocket = DeckyBackend.callable<[], void>("utilities/close_cef_socket");
+
+export default function cefSocketFix() {
+    const reg = window.SteamClient?.User?.RegisterForShutdownStart(async () => {
+        logger.log("Closing CEF socket before shutdown");
+        await closeCEFSocket();
+    });
+
+    if (reg) logger.debug("CEF shutdown handler ready");
+
+    return () => reg?.unregister();
+}

--- a/frontend/src/steamfixes/socket.ts
+++ b/frontend/src/steamfixes/socket.ts
@@ -1,16 +1,16 @@
-import Logger from "../logger";
+import Logger from '../logger';
 
 const logger = new Logger('CEFSocketFix');
 
-const closeCEFSocket = DeckyBackend.callable<[], void>("utilities/close_cef_socket");
+const closeCEFSocket = DeckyBackend.callable<[], void>('utilities/close_cef_socket');
 
 export default function cefSocketFix() {
-    const reg = window.SteamClient?.User?.RegisterForShutdownStart(async () => {
-        logger.log("Closing CEF socket before shutdown");
-        await closeCEFSocket();
-    });
+  const reg = window.SteamClient?.User?.RegisterForShutdownStart(async () => {
+    logger.log('Closing CEF socket before shutdown');
+    await closeCEFSocket();
+  });
 
-    if (reg) logger.debug("CEF shutdown handler ready");
+  if (reg) logger.debug('CEF shutdown handler ready');
 
-    return () => reg?.unregister();
+  return () => reg?.unregister();
 }


### PR DESCRIPTION
this automates lsof and gdb to force close the old CEF debugger socket before steam finishes shutting down (from RegisterForShutdownStart)

Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Fixes #618