### PR TITLE
Ensure boot after network.target

### DIFF
--- a/dist/plugin_loader-prerelease.service
+++ b/dist/plugin_loader-prerelease.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network.target
 [Service]
 Type=simple
 User=root

--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network.target
 [Service]
 Type=simple
 User=root


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
    - Steam deck oled (preview os, beta steam)
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Docs: https://systemd.io/NETWORK_ONLINE/
Probably good practise to wait until the network manager has started before running decky. 
