### PR TITLE
Fix shutdown timeouts

### DIFF
--- a/backend/decky_loader/loader.py
+++ b/backend/decky_loader/loader.py
@@ -104,9 +104,14 @@ class Loader:
     async def enable_reload_wait(self):
         if self.live_reload:
             await sleep(10)
-            if self.watcher:
+            if self.watcher and self.live_reload:
                 self.logger.info("Hot reload enabled")
                 self.watcher.disabled = False
+
+    async def disable_reload(self):
+        if self.watcher:
+            self.watcher.disabled = True
+            self.live_reload = False
 
     async def handle_frontend_assets(self, request: web.Request):
         file = Path(__file__).parent.joinpath("static").joinpath(request.match_info["path"])

--- a/backend/decky_loader/localplatform/localsocket.py
+++ b/backend/decky_loader/localplatform/localsocket.py
@@ -7,14 +7,14 @@ from .localplatform import ON_WINDOWS
 BUFFER_LIMIT = 2 ** 20  # 1 MiB
 
 class UnixSocket:
-    def __init__(self, on_new_message: Callable[[str], Coroutine[Any, Any, Any]]):
+    def __init__(self):
         '''
         on_new_message takes 1 string argument.
         It's return value gets used, if not None, to write data to the socket.
         Method should be async
         '''
         self.socket_addr = f"/tmp/plugin_socket_{time.time()}"
-        self.on_new_message = on_new_message
+        self.on_new_message = None
         self.socket = None
         self.reader = None
         self.writer = None
@@ -22,8 +22,9 @@ class UnixSocket:
         self.open_lock = asyncio.Lock()
         self.active = True
 
-    async def setup_server(self):
+    async def setup_server(self, on_new_message: Callable[[str], Coroutine[Any, Any, Any]]):
         try:
+            self.on_new_message = on_new_message
             self.socket = await asyncio.start_unix_server(self._listen_for_method_call, path=self.socket_addr, limit=BUFFER_LIMIT)
         except asyncio.CancelledError:
             await self.close_socket_connection()
@@ -114,7 +115,7 @@ class UnixSocket:
 
     async def _listen_for_method_call(self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
         self.server_writer = writer
-        while True:
+        while self.active and self.on_new_message:
 
             def _(task: asyncio.Task[str|None]):
                 res = task.result()
@@ -125,18 +126,19 @@ class UnixSocket:
             asyncio.create_task(self.on_new_message(line)).add_done_callback(_)
             
 class PortSocket (UnixSocket):
-    def __init__(self, on_new_message: Callable[[str], Coroutine[Any, Any, Any]]):
+    def __init__(self):
         '''
         on_new_message takes 1 string argument.
         It's return value gets used, if not None, to write data to the socket.
         Method should be async
         '''
-        super().__init__(on_new_message)
+        super().__init__()
         self.host = "127.0.0.1"
         self.port = random.sample(range(40000, 60000), 1)[0]
     
-    async def setup_server(self):
+    async def setup_server(self, on_new_message: Callable[[str], Coroutine[Any, Any, Any]]):
         try:
+            self.on_new_message = on_new_message
             self.socket = await asyncio.start_server(self._listen_for_method_call, host=self.host, port=self.port, limit=BUFFER_LIMIT)
         except asyncio.CancelledError:
             await self.close_socket_connection()

--- a/backend/decky_loader/localplatform/localsocket.py
+++ b/backend/decky_loader/localplatform/localsocket.py
@@ -91,7 +91,7 @@ class UnixSocket:
                 line.extend(err.partial)
                 break
             except asyncio.CancelledError:
-                break
+                raise
             else:
                 break
 

--- a/backend/decky_loader/localplatform/localsocket.py
+++ b/backend/decky_loader/localplatform/localsocket.py
@@ -20,6 +20,7 @@ class UnixSocket:
         self.writer = None
         self.server_writer = None
         self.open_lock = asyncio.Lock()
+        self.active = True
 
     async def setup_server(self):
         try:
@@ -58,6 +59,8 @@ class UnixSocket:
         if self.socket:
             self.socket.close()
             await self.socket.wait_closed()
+        
+        self.active = False
 
     async def read_single_line(self) -> str|None:
         reader, _ = await self.get_socket_connection()
@@ -81,7 +84,7 @@ class UnixSocket:
 
     async def _read_single_line(self, reader: asyncio.StreamReader) -> str:
         line = bytearray()
-        while True:
+        while self.active:
             try:
                 line.extend(await reader.readuntil())
             except asyncio.LimitOverrunError:

--- a/backend/decky_loader/main.py
+++ b/backend/decky_loader/main.py
@@ -118,7 +118,11 @@ class PluginManager:
     async def shutdown(self, _: Application):
         try:
             logger.info(f"Shutting down...")
+            logger.info("Disabling reload...")
+            await self.plugin_loader.disable_reload()
+            logger.info("Killing plugins...")
             await self.plugin_loader.shutdown_plugins()
+            logger.info("Disconnecting from WS...")
             await self.ws.disconnect()
             self.reinject = False
             if self.js_ctx_tab:

--- a/backend/decky_loader/main.py
+++ b/backend/decky_loader/main.py
@@ -101,6 +101,8 @@ class PluginManager:
         self.web_app.add_routes([static("/static", path.join(path.dirname(__file__), 'static'))])
 
     async def handle_crash(self):
+        if not self.reinject:
+            return
         new_time = time()
         if (new_time - self.last_webhelper_exit < 60):
             self.webhelper_crash_count += 1
@@ -123,8 +125,8 @@ class PluginManager:
             logger.info("Killing plugins...")
             await self.plugin_loader.shutdown_plugins()
             logger.info("Disconnecting from WS...")
-            await self.ws.disconnect()
             self.reinject = False
+            await self.ws.disconnect()
             if self.js_ctx_tab:
                 await self.js_ctx_tab.close_websocket()
                 self.js_ctx_tab = None

--- a/backend/decky_loader/plugin/plugin.py
+++ b/backend/decky_loader/plugin/plugin.py
@@ -44,8 +44,7 @@ class PluginWrapper:
 
         self.sandboxed_plugin = SandboxedPlugin(self.name, self.passive, self.flags, self.file, self.plugin_directory, self.plugin_path, self.version, self.author, self.api_version)
         self.proc: Process | None = None
-        # TODO: Maybe make LocalSocket not require on_new_message to make this cleaner
-        self._socket = LocalSocket(self.sandboxed_plugin.on_new_message)
+        self._socket = LocalSocket()
         self._listener_task: Task[Any]
         self._method_call_requests: Dict[str, MethodCallRequest] = {}
 
@@ -147,7 +146,6 @@ class PluginWrapper:
         start_time = time()
         sigtermed = False
         while self.proc and self.proc.is_alive():
-            await sleep(0.1)
             elapsed_time = time() - start_time
             if elapsed_time >= 2 and not sigtermed:
                 sigtermed = True
@@ -156,6 +154,7 @@ class PluginWrapper:
             elif elapsed_time >= 5:
                 self.log.warn(f"Plugin {self.name} still alive 5 seconds after stop request! Sending SIGKILL!")
                 self.terminate(True)
+            await sleep(0.1)
 
     def terminate(self, kill: bool = False):
         if self.proc and self.proc.is_alive():

--- a/backend/decky_loader/plugin/plugin.py
+++ b/backend/decky_loader/plugin/plugin.py
@@ -67,7 +67,7 @@ class PluginWrapper:
         return self.name
     
     async def _response_listener(self):
-        while True:
+        while self._socket.active:
             try:
                 line = await self._socket.read_single_line()
                 if line != None:

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -120,7 +120,7 @@ class SandboxedPlugin:
                     get_event_loop().create_task(self.Plugin._main())
                 else:
                     get_event_loop().create_task(self.Plugin._main(self.Plugin))
-            get_event_loop().create_task(socket.setup_server())
+            get_event_loop().create_task(socket.setup_server(self.on_new_message))
         except:
             self.log.error("Failed to start " + self.name + "!\n" + format_exc())
             sys.exit(0)

--- a/dist/install_prerelease.sh
+++ b/dist/install_prerelease.sh
@@ -34,10 +34,13 @@ curl -L https://raw.githubusercontent.com/SteamDeckHomebrew/decky-loader/main/di
 cat > "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network.target
 [Service]
 Type=simple
 User=root
 Restart=always
+KillMode=process
+TimeoutStopSec=45
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services
 Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}

--- a/dist/install_release.sh
+++ b/dist/install_release.sh
@@ -34,10 +34,13 @@ curl -L https://raw.githubusercontent.com/SteamDeckHomebrew/decky-loader/main/di
 cat > "${HOMEBREW_FOLDER}/services/plugin_loader-backup.service" <<- EOM
 [Unit]
 Description=SteamDeck Plugin Loader
+After=network.target
 [Service]
 Type=simple
 User=root
 Restart=always
+KillMode=process
+TimeoutStopSec=45
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services
 Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}

--- a/dist/plugin_loader-prerelease.service
+++ b/dist/plugin_loader-prerelease.service
@@ -5,6 +5,7 @@ After=network.target
 Type=simple
 User=root
 Restart=always
+KillMode=process
 TimeoutStopSec=45
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services

--- a/dist/plugin_loader-release.service
+++ b/dist/plugin_loader-release.service
@@ -5,6 +5,7 @@ After=network.target
 Type=simple
 User=root
 Restart=always
+KillMode=process
 TimeoutStopSec=45
 ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
 WorkingDirectory=${HOMEBREW_FOLDER}/services


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
   - ~Yet to be tested on real hardware; only tested in a decoupled local environment~
   - Tested on steam deck oled, preview steam branch
- [ ] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This PR (should) fix timeouts from occuring during shutdown of decky. Plugins are now killed 5 seconds after being asked to shutdown, too. 