### PR TITLE
fix: Plugin install from ZIP getting stuck indefinitely

### DIFF
--- a/backend/decky_loader/browser.py
+++ b/backend/decky_loader/browser.py
@@ -213,7 +213,19 @@ class PluginBrowser:
                     return
 
                 else:
-                    name = sub(r"/.+$", "", plugin_json_list[0])
+                    plugin_json_file = plugin_json_list[0]
+                    name = sub(r"/.+$", "", plugin_json_file)
+                    try:
+                        with plugin_zip.open(plugin_json_file) as f:
+                            plugin_json_data = json.loads(f.read().decode('utf-8'))
+                            plugin_name_from_plugin_json = plugin_json_data.get('name')
+                            if plugin_name_from_plugin_json and plugin_name_from_plugin_json.strip():
+                                logger.info(f"Extracted plugin name from {plugin_json_file}: {plugin_name_from_plugin_json}")
+                                name = plugin_name_from_plugin_json
+                            else:
+                                logger.warning(f"Nonexistent or invalid 'name' key value in {plugin_json_file}. Falling back to extracting from path.")
+                    except Exception as e:
+                        logger.error(f"Failed to read or parse {plugin_json_file}: {str(e)}. Falling back to extracting from path.")
 
         try:
             pluginFolderPath = self.find_plugin_folder(name)


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issue: N/A

After debugging why plugin manual ZIP installations sometimes fail to finish and gets stuck I've noticed that plugin name is being extracted from folder name that is in the ZIP and not from the plugin.json file. This name is then used to search for plugin folder later on in the process (```plugin_folder = self.find_plugin_folder(name)```) and since the plugin folder name is pretty much guaranteed to be different than plugin name - assertion (```assert plugin_folder is not None```) is triggered.

This fixes it by reading the plugin name from plugin.json file that is included in the ZIP.
It might also be a good idea to check why the installer gets stuck when the assertion error is triggered but it is out of scope for this PR.
