### PR TITLE
Fix the server-side tracking of updates

### DIFF
--- a/backend/decky_loader/browser.py
+++ b/backend/decky_loader/browser.py
@@ -157,8 +157,16 @@ class PluginBrowser:
         # Will be set later in code
         res_zip = None
 
-        # Check if plugin is installed
+        # Check if plugin was already installed before this
         isInstalled = False
+
+        try:
+            pluginFolderPath = self.find_plugin_folder(name)
+            if pluginFolderPath:
+                isInstalled = True
+        except:
+            logger.error(f"Failed to determine if {name} is already installed, continuing anyway.")
+
         # Preserve plugin order before removing plugin (uninstall alters the order and removes the plugin from the list)
         current_plugin_order = self.settings.getSetting("pluginOrder")[:]
         if self.loader.watcher:
@@ -214,13 +222,6 @@ class PluginBrowser:
 
                 else:
                     name = sub(r"/.+$", "", plugin_json_list[0])
-
-        try:
-            pluginFolderPath = self.find_plugin_folder(name)
-            if pluginFolderPath:
-                isInstalled = True
-        except:
-            logger.error(f"Failed to determine if {name} is already installed, continuing anyway.")
 
         # Check to make sure we got the file
         if res_zip is None:


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Fixes the issue where every 'increment install count' request to the server was sent as a 'new download' even if it should've been 'update from existing install'. (the relevant bit is on line 198)

(Haven't actually tested it as i am doing this from my phone, will update when i get to my laptop)