### PR TITLE
Fix id keyerror on plugin uninstall

### DIFF
--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -186,7 +186,7 @@ class SandboxedPlugin:
 
         if "uninstall" in data:
             self.uninstalling = data.get("uninstall")
-            return None
+            return
 
         d: SocketResponseDict = {"type": SocketMessageType.RESPONSE, "res": None, "success": True, "id": data["id"]}
         try:

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -186,6 +186,7 @@ class SandboxedPlugin:
 
         if "uninstall" in data:
             self.uninstalling = data.get("uninstall")
+            return None;
 
         d: SocketResponseDict = {"type": SocketMessageType.RESPONSE, "res": None, "success": True, "id": data["id"]}
         try:

--- a/backend/decky_loader/plugin/sandboxed_plugin.py
+++ b/backend/decky_loader/plugin/sandboxed_plugin.py
@@ -186,7 +186,7 @@ class SandboxedPlugin:
 
         if "uninstall" in data:
             self.uninstalling = data.get("uninstall")
-            return None;
+            return None
 
         d: SocketResponseDict = {"type": SocketMessageType.RESPONSE, "res": None, "success": True, "id": data["id"]}
         try:


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
    - Completely untested
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: An issue has been reported in the steam deck homebrew discord that uninstalling plugins give a keyerror on uninstall. This fixes that
