### PR TITLE
feat: allow opening hidden plugins

### DIFF
--- a/backend/decky_loader/locales/en-US.json
+++ b/backend/decky_loader/locales/en-US.json
@@ -125,7 +125,6 @@
         "freeze": "Freeze updates",
         "hide": "Quick access: Hide",
         "no_plugin": "No plugins installed!",
-        "open": "Open",
         "plugin_actions": "Plugin Actions",
         "reinstall": "Reinstall",
         "reload": "Reload",

--- a/backend/decky_loader/locales/en-US.json
+++ b/backend/decky_loader/locales/en-US.json
@@ -125,6 +125,7 @@
         "freeze": "Freeze updates",
         "hide": "Quick access: Hide",
         "no_plugin": "No plugins installed!",
+        "open": "Open",
         "plugin_actions": "Plugin Actions",
         "reinstall": "Reinstall",
         "reload": "Reload",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@decky/ui": "^4.8.3",
+    "@decky/ui": "^4.9.0",
     "compare-versions": "^6.1.1",
     "filesize": "^10.1.2",
     "i18next": "^23.11.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@decky/ui':
-        specifier: ^4.8.3
-        version: 4.8.3
+        specifier: ^4.9.0
+        version: 4.9.0
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -218,8 +218,8 @@ packages:
   '@decky/api@1.1.1':
     resolution: {integrity: sha512-R5fkBRHBt5QIQY7Q0AlbVIhlIZ/nTzwBOoi8Rt4Go2fjFnoMKPInCJl6cPjXzimGwl2pyqKJgY6VnH6ar0XrHQ==}
 
-  '@decky/ui@4.8.3':
-    resolution: {integrity: sha512-Y1KciazgvKqMEVBGrWFCTGOqgVi5sHbcQNoCZRMbPpcI0U3j7udl6mkfe/NBa16oRDZ03ljS41SmrAgKAAt/pA==}
+  '@decky/ui@4.9.0':
+    resolution: {integrity: sha512-5iN8UciEpL4WHPdUr4Nzl4/y3CBnLfUN+/1q+WeMUNOzPJICLiwlltfBbyZyMM/ST3nPrDYCLbZCYD9jKWFLXQ==}
 
   '@esbuild/aix-ppc64@0.20.2':
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
@@ -2295,7 +2295,7 @@ snapshots:
 
   '@decky/api@1.1.1': {}
 
-  '@decky/ui@4.8.3': {}
+  '@decky/ui@4.9.0': {}
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -25,7 +25,12 @@ const PluginView: FC = () => {
 
   if (activePlugin) {
     return (
-      <Focusable onCancelButton={closeActivePlugin}>
+      <Focusable
+        onCancelButton={closeActivePlugin}
+        // Needed to focus inside the panel when opening plugin from settings menu
+        // Doesn't seem to do any harm (since this seems to need focus in normal cases too) so I made this unconditional
+        autoFocus
+      >
         <TitleView />
         <div style={{ height: '100%', paddingTop: '16px' }}>
           <ErrorBoundary>{(visible || activePlugin.alwaysRender) && activePlugin.content}</ErrorBoundary>

--- a/frontend/src/components/TitleView.tsx
+++ b/frontend/src/components/TitleView.tsx
@@ -58,7 +58,7 @@ const TitleView: FC = () => {
       >
         <FaArrowLeft style={{ marginTop: '-4px', display: 'block' }} />
       </DialogButton>
-      {activePlugin?.titleView || <div style={{ flex: 0.9 }}>{activePlugin.name}</div>}
+      {activePlugin.titleView || <div style={{ flex: 0.9 }}>{activePlugin.name}</div>}
     </Focusable>
   );
 };

--- a/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
@@ -2,18 +2,27 @@ import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaEyeSlash, FaLock } from 'react-icons/fa';
 
+import { StorePluginVersion } from '../../../../store';
+import NotificationBadge from '../../../NotificationBadge';
+
 interface PluginListLabelProps {
   frozen: boolean;
   hidden: boolean;
   name: string;
   version?: string;
+  update: StorePluginVersion | undefined;
 }
 
-const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, version }) => {
+const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, version, update }) => {
   const { t } = useTranslation();
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
-      <div>
+      <div
+        style={{
+          // needed for NotificationBadge
+          position: 'relative',
+        }}
+      >
         {name}
         {version && (
           <>
@@ -28,6 +37,7 @@ const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, versi
             </span>
           </>
         )}
+        <NotificationBadge show={!!update} style={{ top: '-5px', right: '-10px' }} />
       </div>
       {hidden && (
         <div

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -173,8 +173,10 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
         const frozen = frozenPlugins.includes(name);
         const hidden = hiddenPlugins.includes(name);
 
+        const update = updates?.get(name);
+
         return {
-          label: <PluginListLabel name={name} frozen={frozen} hidden={hidden} version={version} />,
+          label: <PluginListLabel name={name} frozen={frozen} hidden={hidden} version={version} update={update} />,
           position: pluginOrder.indexOf(name),
           data: {
             name,
@@ -182,7 +184,7 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
             hidden,
             isDeveloper,
             version,
-            update: updates?.get(name),
+            update,
             onFreeze: () => frozenPluginsService.update([...frozenPlugins, name]),
             onUnfreeze: () => frozenPluginsService.update(frozenPlugins.filter((pluginName) => name !== pluginName)),
             onHide: () => hiddenPluginsService.update([...hiddenPlugins, name]),

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -5,6 +5,7 @@ import {
   GamepadEvent,
   Menu,
   MenuItem,
+  MenuSeparator,
   Navigation,
   QuickAccessTab,
   ReorderableEntry,
@@ -99,6 +100,9 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
         >
           {t('PluginListIndex.uninstall')}
         </MenuItem>
+
+        <MenuSeparator />
+
         {hidden ? (
           <MenuItem onSelected={onShow}>{t('PluginListIndex.show')}</MenuItem>
         ) : (

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -11,9 +11,10 @@ import {
   ReorderableList,
   showContextMenu,
 } from '@decky/ui';
-import { useEffect, useMemo } from 'react';
+import { CSSProperties, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaDownload, FaEllipsisH, FaRecycle } from 'react-icons/fa';
+import { FaDownload, FaEllipsisH } from 'react-icons/fa';
+import { TbLayoutSidebarRightExpandFilled } from 'react-icons/tb';
 
 import { InstallType } from '../../../../plugin';
 import {
@@ -49,6 +50,17 @@ type PluginTableData = PluginData & {
 
 const reloadPluginBackend = DeckyBackend.callable<[pluginName: string], void>('loader/reload_plugin');
 
+const squareButtonStyle: CSSProperties = {
+  height: '40px',
+  width: '40px',
+  minWidth: '40px',
+  padding: '0',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+};
+
 function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }) {
   const { t } = useTranslation();
 
@@ -63,7 +75,6 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
   const showCtxMenu = (e: MouseEvent | GamepadEvent) => {
     showContextMenu(
       <Menu label={t('PluginListIndex.plugin_actions')}>
-        <MenuItem onSelected={onOpen}>{t('PluginListIndex.open')}</MenuItem>
         <MenuItem
           onSelected={async () => {
             try {
@@ -75,6 +86,7 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
         >
           {t('PluginListIndex.reload')}
         </MenuItem>
+        <MenuItem onSelected={() => reinstallPlugin(name, version)}>{t('PluginListIndex.reinstall')}</MenuItem>
         <MenuItem
           onSelected={() =>
             DeckyPluginLoader.uninstallPlugin(
@@ -103,46 +115,34 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
   };
 
   return (
-    <>
+    <div style={{ display: 'flex', gap: '10px' }}>
       {update ? (
         <DialogButton
-          style={{ height: '40px', minWidth: '60px', marginRight: '10px' }}
+          style={{
+            flex: '1 1',
+            minWidth: 'unset',
+            height: '40px',
+            display: 'flex',
+            gap: '1rem',
+            justifyContent: 'center',
+            alignItems: 'center',
+          }}
           onClick={() => requestPluginInstall(name, update, InstallType.UPDATE)}
           onOKButton={() => requestPluginInstall(name, update, InstallType.UPDATE)}
         >
-          <div style={{ display: 'flex', minWidth: '180px', justifyContent: 'space-between', alignItems: 'center' }}>
-            {t('PluginListIndex.update_to', { name: update.name })}
-            <FaDownload style={{ paddingLeft: '1rem' }} />
-          </div>
+          {t('PluginListIndex.update_to', { name: update.name })} <FaDownload />
         </DialogButton>
-      ) : (
-        <DialogButton
-          style={{ height: '40px', minWidth: '60px', marginRight: '10px' }}
-          onClick={() => reinstallPlugin(name, version)}
-          onOKButton={() => reinstallPlugin(name, version)}
-        >
-          <div style={{ display: 'flex', minWidth: '180px', justifyContent: 'space-between', alignItems: 'center' }}>
-            {t('PluginListIndex.reinstall')}
-            <FaRecycle style={{ paddingLeft: '1rem' }} />
-          </div>
-        </DialogButton>
-      )}
-      <DialogButton
-        style={{
-          height: '40px',
-          width: '40px',
-          padding: '10px 12px',
-          minWidth: '40px',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-        }}
-        onClick={showCtxMenu}
-        onOKButton={showCtxMenu}
-      >
+      ) : null}
+      <DialogButton style={squareButtonStyle} onClick={onOpen} onOKButton={onOpen}>
+        <TbLayoutSidebarRightExpandFilled
+          // make size more consistent with the rest of icons in app
+          size={'1.5rem'}
+        />
+      </DialogButton>
+      <DialogButton style={squareButtonStyle} onClick={showCtxMenu} onOKButton={showCtxMenu}>
         <FaEllipsisH />
       </DialogButton>
-    </>
+    </div>
   );
 }
 
@@ -232,10 +232,11 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
             width: 'auto',
             display: 'flex',
             alignItems: 'center',
+            gap: '1rem',
           }}
         >
           {t('PluginListIndex.update_all', { count: updates.size })}
-          <FaDownload style={{ paddingLeft: '1rem' }} />
+          <FaDownload />
         </DialogButton>
       )}
       <DialogControlsSection style={{ marginTop: 0 }}>


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description

This fixes issue: #734 (see issue for alternatives considered)

This solves the use case where plugins are hidden from the quick access list because access to their panels is not used very often. For example, plugin "ProtonDB Badges" is fire-configure-once-and-forget, so it makes sense to hide it so it doesn't waste space and attention during quick access.

But this doesn't mean the user will never want to access hidden plugin panels to e.g. briefly change configuration. Currently the only way to access the plugin content panel is to unhide the plugin, access it in the quick access list, and then hide it again.

This allows opening plugins from the "Plugins" panel in Decky's settings, even if the plugin is hidden in the quick access list. Clicking the open button opens the plugin in the quick access sidebar, regardless of its hidden status.

Additionally:

- Since the "open" action is expected to be more common than the current "Reinstall" button (which seems to be there because it turns into "Update" when an update is available for the plugin):

    - Add "Open" action as the primary icon button
    - Move "Reinstall" option inside context menu so plugin can always be reinstalled (regardless of available updates)
    - Keep "Update" button in main interactables, but only show it when an update is available

    _(See [my comment below](https://github.com/SteamDeckHomebrew/decky-loader/pull/736#issuecomment-2564306625) for some thoughts around this.)_

- Add notification badge if plugin has updates

    Makes it more consistent with the rest of the app, which already has badges on available updates. It also makes it more obvious now that the "Update" button is only shown conditionally, calling attention to the updatable entries.

This is how the changes look in the "Plugins" settings tab:

![Screenshot](https://github.com/user-attachments/assets/39cf7071-1847-4c52-8953-bafd312c7f9a)