### PR TITLE
 feat: add uninstall button to store 

### DIFF
--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -1,7 +1,7 @@
-import { ButtonItem, Dropdown, Focusable, PanelSectionRow, SingleDropdownOption, SuspensefulImage } from '@decky/ui';
-import { CSSProperties, FC, useState } from 'react';
+import { DialogButton, Dropdown, Focusable, PanelSectionRow, SingleDropdownOption, SuspensefulImage } from '@decky/ui';
+import { FC, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaArrowDown, FaArrowUp, FaCheck, FaDownload, FaRecycle } from 'react-icons/fa';
+import { FaArrowDown, FaArrowUp, FaCheck, FaDownload, FaRecycle, FaTrash } from 'react-icons/fa';
 
 import { InstallType, Plugin } from '../../plugin';
 import { StorePlugin, requestPluginInstall } from '../../store';
@@ -128,76 +128,82 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
             </div>
           )}
         </div>
-        <div>
-          <PanelSectionRow>
-            <Focusable style={{ display: 'flex', gap: '5px', padding: 0 }}>
-              <div
-                className="deckyStoreCardInstallContainer"
-                style={
-                  {
-                    paddingTop: '0px',
-                    paddingBottom: '0px',
-                    flexGrow: 1,
-                    '--field-negative-horizontal-margin': 0,
-                  } as CSSProperties
-                }
+        <PanelSectionRow>
+          <Focusable style={{ display: 'flex', gap: '5px', padding: 0 }}>
+            <DialogButton
+              style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                gap: '5px',
+              }}
+              onClick={() => requestPluginInstall(storePlugin.name, storePlugin.versions[selectedOption], installType)}
+            >
+              {installType === InstallType.UPDATE ? (
+                <>
+                  <FaArrowUp /> {t('PluginCard.plugin_update')}
+                </>
+              ) : installType === InstallType.REINSTALL ? (
+                <>
+                  <FaRecycle /> {t('PluginCard.plugin_reinstall')}
+                </>
+              ) : installType === InstallType.DOWNGRADE ? (
+                <>
+                  <FaArrowDown /> {t('PluginCard.plugin_downgrade')}
+                </>
+              ) : installType === InstallType.OVERWRITE ? (
+                <>
+                  <FaDownload /> {t('PluginCard.plugin_overwrite')}
+                </>
+              ) : (
+                // installType === InstallType.INSTALL (also fallback)
+                <>
+                  <FaDownload /> {t('PluginCard.plugin_install')}
+                </>
+              )}
+            </DialogButton>
+            {installedPlugin && installedVersionIndex === selectedOption ? (
+              <DialogButton
+                style={{
+                  display: 'flex',
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  minWidth: '40px',
+                  flex: '1 1',
+                  padding: '0',
+                }}
+                onClick={() => {
+                  DeckyPluginLoader.uninstallPlugin(
+                    installedPlugin.name,
+                    t('PluginLoader.plugin_uninstall.title', { name: installedPlugin.name }),
+                    t('PluginLoader.plugin_uninstall.button'),
+                    t('PluginLoader.plugin_uninstall.desc', { name: installedPlugin.name }),
+                  );
+                }}
               >
-                <ButtonItem
-                  bottomSeparator="none"
-                  layout="below"
-                  onClick={() =>
-                    requestPluginInstall(storePlugin.name, storePlugin.versions[selectedOption], installType)
-                  }
-                >
-                  <span
-                    style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '5px' }}
-                  >
-                    {installType === InstallType.UPDATE ? (
-                      <>
-                        <FaArrowUp /> {t('PluginCard.plugin_update')}
-                      </>
-                    ) : installType === InstallType.REINSTALL ? (
-                      <>
-                        <FaRecycle /> {t('PluginCard.plugin_reinstall')}
-                      </>
-                    ) : installType === InstallType.DOWNGRADE ? (
-                      <>
-                        <FaArrowDown /> {t('PluginCard.plugin_downgrade')}
-                      </>
-                    ) : installType === InstallType.OVERWRITE ? (
-                      <>
-                        <FaDownload /> {t('PluginCard.plugin_overwrite')}
-                      </>
-                    ) : (
-                      // installType === InstallType.INSTALL (also fallback)
-                      <>
-                        <FaDownload /> {t('PluginCard.plugin_install')}
-                      </>
-                    )}
-                  </span>
-                </ButtonItem>
-              </div>
-              <div style={{ minWidth: '130px' }}>
-                <Dropdown
-                  rgOptions={
-                    storePlugin.versions.map((version, index) => ({
-                      data: index,
-                      label: (
-                        <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
-                          {version.name}
-                          {installedPlugin && installedVersionIndex === index ? <FaCheck /> : null}
-                        </div>
-                      ),
-                    })) as SingleDropdownOption[]
-                  }
-                  menuLabel={t('PluginCard.plugin_version_label') as string}
-                  selectedOption={selectedOption}
-                  onChange={({ data }) => setSelectedOption(data)}
-                />
-              </div>
-            </Focusable>
-          </PanelSectionRow>
-        </div>
+                <FaTrash />
+              </DialogButton>
+            ) : null}
+            <div style={{ minWidth: '130px' }}>
+              <Dropdown
+                rgOptions={storePlugin.versions.map(
+                  (version, index): SingleDropdownOption => ({
+                    data: index,
+                    label: (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '5px' }}>
+                        {version.name}
+                        {installedPlugin && installedVersionIndex === index ? <FaCheck /> : null}
+                      </div>
+                    ),
+                  }),
+                )}
+                menuLabel={t('PluginCard.plugin_version_label') as string}
+                selectedOption={selectedOption}
+                onChange={({ data }) => setSelectedOption(data)}
+              />
+            </div>
+          </Focusable>
+        </PanelSectionRow>
       </div>
     </div>
   );

--- a/frontend/src/components/store/PluginCard.tsx
+++ b/frontend/src/components/store/PluginCard.tsx
@@ -32,7 +32,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
 
   return (
     <div
-      className="deckyStoreCard"
       style={{
         marginLeft: '20px',
         marginRight: '20px',
@@ -41,7 +40,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
       }}
     >
       <div
-        className="deckyStoreCardImageContainer"
         style={{
           width: '320px',
           height: '200px',
@@ -49,7 +47,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
         }}
       >
         <SuspensefulImage
-          className="deckyStoreCardImage"
           suspenseHeight="200px"
           suspenseWidth="320px"
           style={{
@@ -61,7 +58,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
         />
       </div>
       <div
-        className="deckyStoreCardInfo"
         style={{
           width: 'calc(100% - 320px)', // The calc is here so that the info section doesn't expand into the image
           display: 'flex',
@@ -73,7 +69,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
       >
         <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
           <span
-            className="deckyStoreCardTitle"
             style={{
               fontSize: '1.25em',
               fontWeight: 'bold',
@@ -86,7 +81,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
             {storePlugin.name}
           </span>
           <span
-            className="deckyStoreCardAuthor"
             style={{
               marginRight: 'auto',
               fontSize: '1em',
@@ -95,7 +89,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
             {storePlugin.author}
           </span>
           <span
-            className="deckyStoreCardDescription"
             style={{
               fontSize: '13px',
               color: '#969696',
@@ -115,7 +108,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
           </span>
           {root && (
             <div
-              className="deckyStoreCardDescription deckyStoreCardDescriptionRoot"
               style={{
                 fontSize: '13px',
                 color: '#fee75c',
@@ -124,7 +116,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
             >
               <i>{t('PluginCard.plugin_full_access')}</i>{' '}
               <ExternalLink
-                className="deckyStoreCardDescriptionRootLink"
                 href="https://deckbrew.xyz/root"
                 target="_blank"
                 style={{
@@ -137,7 +128,7 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
             </div>
           )}
         </div>
-        <div className="deckyStoreCardButtonRow">
+        <div>
           <PanelSectionRow>
             <Focusable style={{ display: 'flex', gap: '5px', padding: 0 }}>
               <div
@@ -159,7 +150,6 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
                   }
                 >
                   <span
-                    className="deckyStoreCardInstallText"
                     style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '5px' }}
                   >
                     {installType === InstallType.UPDATE ? (
@@ -187,7 +177,7 @@ const PluginCard: FC<PluginCardProps> = ({ storePlugin, installedPlugin }) => {
                   </span>
                 </ButtonItem>
               </div>
-              <div className="deckyStoreCardVersionContainer" style={{ minWidth: '130px' }}>
+              <div style={{ minWidth: '130px' }}>
                 <Dropdown
                   rgOptions={
                     storePlugin.versions.map((version, index) => ({

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -109,11 +109,6 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
 
   return (
     <>
-      <style>{`
-              .deckyStoreCardInstallContainer > .Panel {
-                padding: 0;
-              }
-            `}</style>
       {/* This should be used once filtering is added
 
       <PanelSectionRow>


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description

This fixes issue: NONE

This is a followup to PR #733. After discussing with @TrainDoctor on Discord he suggested it would be a good idea to also add an uninstall button to the store next to the "Reinstall" button (to plugins which are already installed).

![Screenshot](https://github.com/user-attachments/assets/8c191a7b-d11f-4a2e-afaa-1136672fa25f)

To make the functionality more obvious, the button will only be shown along with "Reinstall", i.e. when the currently installed version is selected in the dropdown.