### PR TITLE
chore(flake): Add setuptools in order to build on a minimal Nix system

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,45 +11,57 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, poetry2nix }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      poetry2nix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
         p2n = (poetry2nix.lib.mkPoetry2Nix { inherit pkgs; });
-      in {
-        devShells.default = (p2n.mkPoetryEnv {
-          projectDir = self + "/backend";
-          # pyinstaller fails to compile so precompiled it is
-          overrides = p2n.overrides.withDefaults (final: prev: {
-            pyinstaller = prev.pyinstaller.override { preferWheel = true; };
-            pyright = null;
-          });
-        }).env.overrideAttrs (oldAttrs: {
-          shellHook = ''
-            PYTHONPATH=`which python`
-            FILE=.vscode/settings.json
-            if [ -f "$FILE" ]; then
-              jq --arg pythonpath "$PYTHONPATH" '.["python.defaultInterpreterPath"] = $pythonpath' $FILE > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-            else
-              echo "{\"python.defaultInterpreterPath\": \"$PYTHONPATH\"}" > "$FILE"
-            fi
-          '';
-          UV_USE_IO_URING = 0; # work around node#48444
-          buildInputs = with pkgs; [
-            nodejs_22
-            nodePackages.pnpm
-            poetry
-            jq
-            # fixes local pyright not being able to see the pythonpath properly.
-            (pkgs.writeShellScriptBin "pyright" ''
-              ${pkgs.pyright}/bin/pyright --pythonpath `which python3` "$@" '')
-            (pkgs.writeShellScriptBin "pyright-langserver" ''
-              ${pkgs.pyright}/bin/pyright-langserver --pythonpath `which python3` "$@" '')
-            (pkgs.writeShellScriptBin "pyright-python" ''
-              ${pkgs.pyright}/bin/pyright-python --pythonpath `which python3` "$@" '')
-            (pkgs.writeShellScriptBin "pyright-python-langserver" ''
-              ${pkgs.pyright}/bin/pyright-python-langserver --pythonpath `which python3` "$@" '')
-          ];
-        });
-      });
+      in
+      {
+        devShells.default =
+          (p2n.mkPoetryEnv {
+            projectDir = self + "/backend";
+            # pyinstaller fails to compile so precompiled it is
+            overrides = p2n.overrides.withDefaults (
+              final: prev: {
+                pyinstaller = prev.pyinstaller.override { preferWheel = true; };
+                pyright = null;
+              }
+            );
+          }).env.overrideAttrs
+            (oldAttrs: {
+              shellHook = ''
+                PYTHONPATH=`which python`
+                FILE=.vscode/settings.json
+                if [ -f "$FILE" ]; then
+                  jq --arg pythonpath "$PYTHONPATH" '.["python.defaultInterpreterPath"] = $pythonpath' $FILE > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+                else
+                  echo "{\"python.defaultInterpreterPath\": \"$PYTHONPATH\"}" > "$FILE"
+                fi
+              '';
+              UV_USE_IO_URING = 0; # work around node#48444
+              nativeBuildInputs = with pkgs; [
+                python311Packages.setuptools
+              ];
+              buildInputs = with pkgs; [
+                nodejs_22
+                nodePackages.pnpm
+                poetry
+                jq
+                # fixes local pyright not being able to see the pythonpath properly.
+                (pkgs.writeShellScriptBin "pyright" ''${pkgs.pyright}/bin/pyright --pythonpath `which python3` "$@" '')
+                (pkgs.writeShellScriptBin "pyright-langserver" ''${pkgs.pyright}/bin/pyright-langserver --pythonpath `which python3` "$@" '')
+                (pkgs.writeShellScriptBin "pyright-python" ''${pkgs.pyright}/bin/pyright-python --pythonpath `which python3` "$@" '')
+                (pkgs.writeShellScriptBin "pyright-python-langserver" ''${pkgs.pyright}/bin/pyright-python-langserver --pythonpath `which python3` "$@" '')
+              ];
+            });
+      }
+    );
 }


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This is a very basic change to the `flake.nix` file, fixing a failure to activate the Nix shell due to missing `setuptools` on my system. A completely fresh Nix environment would not have any python packages installed, so I added it, in order to build `propcache`.

```log
error: builder for '/nix/store/3kvfya2v3vnvbiglh2a5qyh2rai39w3f-python3.11-propcache-0.2.0.drv' failed with exit code 2;
       last 25 log lines:
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "/nix/store/hj15fswklkqnsdyqhgap248j7c88kxx9-python3.11-pip-24.0/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_impl.py", line 186, in prepare_metadata_for_build_wheel
       >     return self._call_hook('prepare_metadata_for_build_wheel', {
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "/nix/store/hj15fswklkqnsdyqhgap248j7c88kxx9-python3.11-pip-24.0/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_impl.py", line 321, in _call_hook
       >     raise BackendUnavailable(data.get('traceback', ''))
       > pip._vendor.pyproject_hooks._impl.BackendUnavailable: Traceback (most recent call last):
       >   File "/nix/store/hj15fswklkqnsdyqhgap248j7c88kxx9-python3.11-pip-24.0/lib/python3.11/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 77, in _build_backend
       >     obj = import_module(mod_path)
       >           ^^^^^^^^^^^^^^^^^^^^^^^
       >   File "/nix/store/6b1fqdwb3g56j5pazv8zkx9qd0mv3wiz-python3-3.11.9/lib/python3.11/importlib/__init__.py", line 126, in import_module
       >     return _bootstrap._gcd_import(name[level:], package, level)
       >            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       >   File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
       >   File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
       >   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
       >   File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
       >   File "<frozen importlib._bootstrap_external>", line 940, in exec_module
       >   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
       >   File "/build/propcache-0.2.0/packaging/pep517_backend/hooks.py", line 5, in <module>
       >     from setuptools.build_meta import *  # Re-exporting PEP 517 hooks  # pylint: disable=unused-wildcard-import,wildcard-import  # noqa: E501, F401, F403
       >     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       > ModuleNotFoundError: No module named 'setuptools'
       > 
       > 
       For full logs, run 'nix log /nix/store/3kvfya2v3vnvbiglh2a5qyh2rai39w3f-python3.11-propcache-0.2.0.drv'.
error: 1 dependencies of derivation '/nix/store/szamcj6rz3fb1y7xrhdlzg02z3h1hk91-python3-3.11.9-env.drv' failed to build
error: 1 dependencies of derivation '/nix/store/z40aw3p5aa88fgq26cfbyl6h2d90jxnm-interactive-python3-3.11.9-environment-env.drv' failed to build
```

It's added as a `nativeBuildInputs`, as it's only used for building the environment.

P.S. I also ran (by mistake) [nixfmt](https://github.com/NixOS/nixfmt) on the file. But if you want to stick with the old formatting, I'm happy to recommit keeping it as it was.