### PR TITLE
Add support of files from `data/<plugin>/assets/` to be fetched from Front-End

### DIFF
--- a/backend/decky_loader/loader.py
+++ b/backend/decky_loader/loader.py
@@ -8,6 +8,7 @@ from typing import Any, Tuple, Dict, cast
 
 from aiohttp import web
 from os.path import exists
+from decky_loader.helpers import get_homebrew_path
 from watchdog.events import RegexMatchingEventHandler, FileSystemEvent
 from watchdog.observers import Observer
 
@@ -140,7 +141,17 @@ class Loader:
         plugin = self.plugins[request.match_info["plugin_name"]]
         file = path.join(self.plugin_path, plugin.plugin_directory, "dist/assets", request.match_info["path"])
 
+        if not path.exists(file):
+            file = self.handle_plugin_frontend_assets_from_data(request)
+
         return web.FileResponse(file, headers={"Cache-Control": "no-cache"})
+
+    def handle_plugin_frontend_assets_from_data(self, request: web.Request) -> str:
+        plugin = self.plugins[request.match_info["plugin_name"]]
+        home = get_homebrew_path()
+        file = path.join(home, "data", plugin.plugin_directory, "assets", request.match_info["path"])
+
+        return file
 
     async def handle_frontend_bundle(self, request: web.Request):
         plugin = self.plugins[request.match_info["plugin_name"]]


### PR DESCRIPTION

Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This **Merge Reqeuest** extends support of fetching files from `/homebrew/data/<plugin_name>/assets` in Front-End using `fetch`. Example:
```js
fetch('http://127.0.0.1:1337/plugins/PlayTime/assets/444.png')
```
or by using directly in `CSS` `url`'s:
<details>
  <summary>Steam Big Picture example</summary>

![image](https://github.com/user-attachments/assets/8ab1bfcc-aaa9-495d-a342-1cd59578706d)
</details>

<hr/>

Currently, we can fetch assets which are only in`/homebrew/plugins/<plugin_name>/dist/assets` which is okay when developer add assets by himself.

I have an use case where I want to allow users to add their own game covers image into [SDH-PlayTime](https://github.com/0u73r-h34v3n/SDH-PlayTime) plugin.

It is not very convenient to allow user to add something into `plugins` folder, a thing what I don't want to happen, because it is too risky for them, so a safer way is to just add support of of `handle_plugin_frontend_assets` to one more folder which is ``/homebrew/data/<plugin_name>/assets``

I tested on my Steam Deck and everything works as intended:
![image](https://github.com/user-attachments/assets/a47aa249-5817-4b05-99f9-7026226e1fab)


