### PR TITLE
fix: swap Most/Least downloaded drop down in english store

### DIFF
--- a/backend/decky_loader/locales/en-US.json
+++ b/backend/decky_loader/locales/en-US.json
@@ -256,8 +256,8 @@
             "alph_desc": "Alphabetical (A to Z)",
             "date_asce": "Oldest First",
             "date_desc": "Newest First",
-            "downloads_asce": "Least Downloaded First",
-            "downloads_desc": "Most Downloaded First",
+            "downloads_asce": "Most Downloaded First",
+            "downloads_desc": "Least Downloaded First",
             "title": "Browse"
         },
         "store_testing_cta": "Please consider testing new plugins to help the Decky Loader team!",


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [ ] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Least and Most Downloaded sort options in English store appear to be swapped. I dont know for certain but I would think SteamGridDB has been downloaded way more than XIVOmega plugin.

This PR simply swaps the labels in the DD, but if these are mismatched for all other translations, we could consider adjusting the labels in store.tsx


![image](https://github.com/user-attachments/assets/8828169a-e626-4401-b8f5-ba600eb4d4a3)
