### PR TITLE
Simplify the typing of the plugin URL for users

### DIFF
--- a/frontend/src/components/settings/pages/developer/index.tsx
+++ b/frontend/src/components/settings/pages/developer/index.tsx
@@ -72,7 +72,15 @@ export default function DeveloperSettings() {
           }
           icon={<FaLink style={{ display: 'block' }} />}
         >
-          <DialogButton disabled={pluginURL.length == 0} onClick={() => installFromURL(pluginURL)}>
+          <DialogButton disabled={pluginURL.length == 0}
+            onClick={() => {
+              if (/^https?:\/\//.test(pluginURL)){
+                installFromURL(pluginURL);
+              } else {
+                installFromURL("https://" + pluginURL);
+              }
+            }}
+          >
             {t('SettingsDeveloperIndex.third_party_plugins.button_install')}
           </DialogButton>
         </Field>

--- a/frontend/src/components/settings/pages/developer/index.tsx
+++ b/frontend/src/components/settings/pages/developer/index.tsx
@@ -72,12 +72,13 @@ export default function DeveloperSettings() {
           }
           icon={<FaLink style={{ display: 'block' }} />}
         >
-          <DialogButton disabled={pluginURL.length == 0}
+          <DialogButton
+            disabled={pluginURL.length == 0}
             onClick={() => {
-              if (/^https?:\/\//.test(pluginURL)){
+              if (/^https?:\/\//.test(pluginURL)) {
                 installFromURL(pluginURL);
               } else {
-                installFromURL("https://" + pluginURL);
+                installFromURL('https://' + pluginURL);
               }
             }}
           >


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

This PR allows the user to write the plugin URL more easily. If the URL does not contain https:// or http://, the https protocol will be added by default.

| User input                     | Result                         |
| ------------------------------ | ------------------------------ |
| example.com/plugin.zip         | https://example.com/plugin.zip |
| https://example.com/plugin.zip | https://example.com/plugin.zip |
| http://example.com/plugin.zip  | http://example.com/plugin.zip  |
