### PR TITLE
Client side sorting/filtering for the Store page

### DIFF
--- a/backend/decky_loader/locales/en-US.json
+++ b/backend/decky_loader/locales/en-US.json
@@ -237,7 +237,12 @@
         },
         "store_filter": {
             "label": "Filter",
-            "label_def": "All"
+            "label_def": "All",
+            "options": {
+                "all": "All",
+                "installed": "Installed",
+                "not_installed": "Not Installed"
+            }
         },
         "store_search": {
             "label": "Search"

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -19,7 +19,7 @@ import ExternalLink from '../ExternalLink';
 import PluginCard from './PluginCard';
 
 interface DropdownOptions<TData = unknown> extends SingleDropdownOption {
-    data: TData;
+  data: TData;
 }
 
 const logger = new Logger('Store');

--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -1,8 +1,8 @@
 import {
   Dropdown,
-  DropdownOption,
   Focusable,
   PanelSectionRow,
+  SingleDropdownOption,
   SteamSpinner,
   Tabs,
   TextField,
@@ -13,7 +13,7 @@ import { useTranslation } from 'react-i18next';
 
 import logo from '../../../assets/plugin_store.png';
 import Logger from '../../logger';
-import { SortDirections, SortOptions, Store, StorePlugin, getPluginList, getStore } from '../../store';
+import { Store, StorePlugin, getPluginList, getStore } from '../../store';
 import { useDeckyState } from '../DeckyState';
 import ExternalLink from '../ExternalLink';
 import PluginCard from './PluginCard';
@@ -63,39 +63,107 @@ const StorePage: FC<{}> = () => {
   );
 };
 
+type ArrayPredicate = Parameters<Array<StorePlugin>['sort']>[0];
+type SortKeys = 'name_asc' | 'name_dec' | 'date_asc' | 'date_dec' | 'dl_asc' | 'dl_dec';
+enum StoreFilter {
+  All = 'all',
+  Installed = 'installed',
+  NotInstalled = 'not_installed'
+}
+
+const sortOptions: Record<SortKeys, ArrayPredicate> = {
+  'name_asc': (a, b) => a.name.localeCompare(b.name),
+  'name_dec': (a, b) => b.name.localeCompare(a.name),
+  'date_asc': (a, b) => new Date(a.updated).valueOf() - new Date(b.updated).valueOf(),
+  'date_dec': (a, b) => new Date(b.updated).valueOf() - new Date(a.updated).valueOf(),
+  'dl_asc': (a, b) => b.downloads - a.downloads,
+  'dl_dec': (a, b) => a.downloads - b.downloads,
+};
+
+interface DropdownOptions<TData = unknown> extends SingleDropdownOption {
+    data: TData;
+}
+
 const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }> = ({ setPluginCount }) => {
   const { t } = useTranslation();
 
   const dropdownSortOptions = useMemo(
-    (): DropdownOption[] => [
+    (): DropdownOptions<SortKeys>[] => [
       // ascending and descending order are the wrong way around for the alphabetical sort
       // this is because it was initially done incorrectly for i18n and 'fixing' it would
       // make all the translations incorrect
-      { data: [SortOptions.name, SortDirections.ascending], label: t('Store.store_tabs.alph_desc') },
-      { data: [SortOptions.name, SortDirections.descending], label: t('Store.store_tabs.alph_asce') },
-      { data: [SortOptions.date, SortDirections.ascending], label: t('Store.store_tabs.date_asce') },
-      { data: [SortOptions.date, SortDirections.descending], label: t('Store.store_tabs.date_desc') },
-      { data: [SortOptions.downloads, SortDirections.descending], label: t('Store.store_tabs.downloads_desc') },
-      { data: [SortOptions.downloads, SortDirections.ascending], label: t('Store.store_tabs.downloads_asce') },
+      { data: 'name_asc', label: t('Store.store_tabs.alph_desc') },
+      { data: 'name_dec', label: t('Store.store_tabs.alph_asce') },
+      { data: 'date_asc', label: t('Store.store_tabs.date_asce') },
+      { data: 'date_dec', label: t('Store.store_tabs.date_desc') },
+      { data: 'dl_asc', label: t('Store.store_tabs.downloads_desc') },
+      { data: 'dl_dec', label: t('Store.store_tabs.downloads_asce') },
     ],
     [],
   );
 
-  // const filterOptions = useMemo((): DropdownOption[] => [{ data: 1, label: 'All' }], []);
-  const [selectedSort, setSort] = useState<[SortOptions, SortDirections]>(dropdownSortOptions[0].data);
-  // const [selectedFilter, setFilter] = useState<number>(filterOptions[0].data);
+  // Our list of filters
+  const filterOptions = useMemo(() => Object.keys(StoreFilter).map<DropdownOptions<StoreFilter>>((key) => ({ 
+    data: StoreFilter[key as keyof typeof StoreFilter], 
+    label: t(`Store.store_filter.options.${StoreFilter[key as keyof typeof StoreFilter]}`) 
+  }), {}), []);
+
+  const [selectedSort, setSort] = useState<DropdownOptions<SortKeys>['data']>(dropdownSortOptions[0].data);
+  const [filter, setFilter] = useState<StoreFilter>(filterOptions[0].data);
   const [searchFieldValue, setSearchValue] = useState<string>('');
   const [pluginList, setPluginList] = useState<StorePlugin[] | null>(null);
   const [isTesting, setIsTesting] = useState<boolean>(false);
 
+  const { plugins: installedPlugins } = useDeckyState();
+
+  // TODO: I recommend using the ID here instead of a name, we already have them in the plugins list
+  const hasInstalledPlugin = (plugin: StorePlugin) => installedPlugins?.find((installedPlugin) => installedPlugin.name === plugin.name);
+
+  const filterPlugin = (plugin: StorePlugin): boolean => {
+    switch (filter) {
+      case StoreFilter.Installed:
+        return !!hasInstalledPlugin(plugin);
+      case StoreFilter.NotInstalled:
+        return !hasInstalledPlugin(plugin);
+      default:
+        return true;
+    }
+  }
+
+  const renderedList = useMemo(() => {
+    // Use an empty array in case it's null
+    const plugins = pluginList || [];
+    return (
+      <>
+        {
+          plugins
+            .filter(filterPlugin)
+            .filter((plugin) => (
+              plugin.name.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
+              plugin.description.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
+              plugin.author.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
+              plugin.tags.some((tag) => tag.toLowerCase().includes(searchFieldValue.toLowerCase()))
+            ))
+            .sort(sortOptions[selectedSort])
+            .map((plugin) => (
+              <PluginCard
+                storePlugin={plugin}
+                installedPlugin={hasInstalledPlugin(plugin)}
+              />
+            ))
+        }
+      </>
+    )
+  }, [pluginList, filter, searchFieldValue, selectedSort, installedPlugins, sortOptions]);
+
   useEffect(() => {
     (async () => {
-      const res = await getPluginList(selectedSort[0], selectedSort[1]);
+      const res = await getPluginList();
       logger.debug('got data!', res);
       setPluginList(res);
       setPluginCount(res.length);
     })();
-  }, [selectedSort]);
+  }, []);
 
   useEffect(() => {
     (async () => {
@@ -105,70 +173,20 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
     })();
   }, []);
 
-  const { plugins: installedPlugins } = useDeckyState();
-
   return (
     <>
       <style>{`
-              .deckyStoreCardInstallContainer > .Panel {
-                padding: 0;
-              }
-            `}</style>
-      {/* This should be used once filtering is added
-
+        .deckyStoreCardInstallContainer > .Panel {
+          padding: 0;
+        }
+      `}</style>
       <PanelSectionRow>
-        <Focusable style={{ display: 'flex', maxWidth: '100%' }}>
+        <Focusable style={{ display: 'flex', maxWidth: '100%', gap: "1rem" }}>
           <div
             style={{
               display: 'flex',
               flexDirection: 'column',
-              width: '47.5%',
-            }}
-          >
-            <span className="DialogLabel">{t("Store.store_sort.label")}</span>
-            <Dropdown
-              menuLabel={t("Store.store_sort.label") as string}
-              rgOptions={dropdownSortOptions}
-              strDefaultLabel={t("Store.store_sort.label_def") as string}
-              selectedOption={selectedSort}
-              onChange={(e) => setSort(e.data)}
-            />
-          </div>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              width: '47.5%',
-              marginLeft: 'auto',
-            }}
-          >
-            <span className="DialogLabel">{t("Store.store_filter.label")}</span>
-            <Dropdown
-              menuLabel={t("Store.store_filter.label")}
-              rgOptions={filterOptions}
-              strDefaultLabel={t("Store.store_filter.label_def")}
-              selectedOption={selectedFilter}
-              onChange={(e) => setFilter(e.data)}
-            />
-          </div>
-        </Focusable>
-      </PanelSectionRow>
-      <div style={{ justifyContent: 'center', display: 'flex' }}>
-        <Focusable style={{ display: 'flex', alignItems: 'center', width: '96%' }}>
-          <div style={{ width: '100%' }}>
-            <TextField label={t("Store.store_search.label")} value={searchFieldValue} onChange={(e) => setSearchValue(e.target.value)} />
-          </div>
-        </Focusable>
-      </div>
-      */}
-      <PanelSectionRow>
-        <Focusable style={{ display: 'flex', maxWidth: '100%' }}>
-          <div
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              minWidth: '100%',
-              maxWidth: '100%',
+              width: '100%'
             }}
           >
             <span className="DialogLabel">{t('Store.store_sort.label')}</span>
@@ -178,6 +196,22 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
               strDefaultLabel={t('Store.store_sort.label_def') as string}
               selectedOption={selectedSort}
               onChange={(e) => setSort(e.data)}
+            />
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              width: '100%'
+            }}
+          >
+            <span className="DialogLabel">{t("Store.store_filter.label")}</span>
+            <Dropdown
+              menuLabel={t("Store.store_filter.label")}
+              rgOptions={filterOptions}
+              strDefaultLabel={t("Store.store_filter.label_def")}
+              selectedOption={filter}
+              onChange={(e) => setFilter(e.data)}
             />
           </div>
         </Focusable>
@@ -228,23 +262,7 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
           <div style={{ height: '100%' }}>
             <SteamSpinner background="transparent" />
           </div>
-        ) : (
-          pluginList
-            .filter((plugin: StorePlugin) => {
-              return (
-                plugin.name.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.description.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.author.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.tags.some((tag: string) => tag.toLowerCase().includes(searchFieldValue.toLowerCase()))
-              );
-            })
-            .map((plugin: StorePlugin) => (
-              <PluginCard
-                storePlugin={plugin}
-                installedPlugin={installedPlugins.find((installedPlugin) => installedPlugin.name === plugin.name)}
-              />
-            ))
-        )}
+        ) : renderedList}
       </div>
     </>
   );

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -23,6 +23,9 @@ export enum SortDirections {
 export interface StorePluginVersion {
   name: string;
   hash: string;
+  created: Date;
+  downloads: number;
+  updates: number;
   artifact: string | undefined | null;
 }
 
@@ -34,6 +37,10 @@ export interface StorePlugin {
   description: string;
   tags: string[];
   image_url: string;
+  downloads: number;
+  updates: number;
+  created: Date;
+  updated: Date;
 }
 
 export interface PluginInstallRequest {

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -9,6 +9,8 @@ export enum Store {
   Custom,
 }
 
+export type SortKeys = `${keyof typeof SortOptions}-${keyof typeof SortDirections}`;
+
 export enum SortOptions {
   name = 'name',
   date = 'date',
@@ -18,6 +20,12 @@ export enum SortOptions {
 export enum SortDirections {
   ascending = 'asc',
   descending = 'desc',
+}
+
+export enum StoreFilter {
+  All = 'all',
+  Installed = 'installed',
+  NotInstalled = 'not_installed'
 }
 
 export interface StorePluginVersion {

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -25,7 +25,7 @@ export enum SortDirections {
 export enum StoreFilter {
   All = 'all',
   Installed = 'installed',
-  NotInstalled = 'not_installed'
+  NotInstalled = 'not_installed',
 }
 
 export interface StorePluginVersion {


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [x] This is a new feature

# Description

This fixes issue: #768
**NOTE:** This fix doesn't change the backend and the original functionality of fetching with sort still has it's issue. 

Currently the way that the frontend sorts the plugin lists by going through the backend and making new network requests each time. This means wasted bandwidth and added latency for every time you want to change sorting order. Over time, more plugins will mean a bigger network response.

This PR introduces client side sorting and also filtering. The plugin list is fetched once when the component loads, and subsequent filtering and sorting is done on the client. This means we're only fetching data once on page load.

I also did expose a few missing properties for `StorePlugin` as part of this change and shouldn't affect functionality of the rest of the app.

I also did make a few adjustments to how the dropdown for sorting is handled with data opting for a singular key instead of the tuple. For filtering, I did opt for a pattern which allows for a more seamless integration of new filter patterns:
1. Add new filter to enum.
2. Create translation key matching the enum string value in the proper path.
3. Add functionality for the filtering in the `filterPlugin` function.

I'm interested in your thoughts on this implementation.

# Demo
![image](https://github.com/user-attachments/assets/273c2423-142d-4839-9390-f0d87ceae2d8)
