### PR TITLE
fix(deps): update @decky/ui to version 4.10.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@decky/ui": "^4.8.3",
+    "@decky/ui": "^4.10.1",
     "compare-versions": "^6.1.1",
     "filesize": "^10.1.2",
     "i18next": "^23.11.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@decky/ui": "^4.10.1",
+    "@decky/ui": "^4.10.2",
     "compare-versions": "^6.1.1",
     "filesize": "^10.1.2",
     "i18next": "^23.11.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@decky/ui':
-        specifier: ^4.10.1
-        version: 4.10.1
+        specifier: ^4.10.2
+        version: 4.10.2
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -218,8 +218,8 @@ packages:
   '@decky/api@1.1.1':
     resolution: {integrity: sha512-R5fkBRHBt5QIQY7Q0AlbVIhlIZ/nTzwBOoi8Rt4Go2fjFnoMKPInCJl6cPjXzimGwl2pyqKJgY6VnH6ar0XrHQ==}
 
-  '@decky/ui@4.10.1':
-    resolution: {integrity: sha512-8rTqVjjXOGJw2oa5BrT1pFY9X8DVAc3E89d4ya93kq5ixK8zQF4FKxnFPYiJ/7w354mVZGdgpx1L5RmZ3Q7e+g==}
+  '@decky/ui@4.10.2':
+    resolution: {integrity: sha512-dfY/OEI/rhG4d3Tvx4Y3TLmBrJ+nAm2RTbkoOJ3VAglql3Lu7RY2ixeDFbs21ZWWzWh/C+9dAQKjQ4lx4d1f2g==}
 
   '@esbuild/aix-ppc64@0.20.2':
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
@@ -2295,7 +2295,7 @@ snapshots:
 
   '@decky/api@1.1.1': {}
 
-  '@decky/ui@4.10.1': {}
+  '@decky/ui@4.10.2': {}
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@decky/ui':
-        specifier: ^4.8.3
-        version: 4.8.3
+        specifier: ^4.10.1
+        version: 4.10.1
       compare-versions:
         specifier: ^6.1.1
         version: 6.1.1
@@ -218,8 +218,8 @@ packages:
   '@decky/api@1.1.1':
     resolution: {integrity: sha512-R5fkBRHBt5QIQY7Q0AlbVIhlIZ/nTzwBOoi8Rt4Go2fjFnoMKPInCJl6cPjXzimGwl2pyqKJgY6VnH6ar0XrHQ==}
 
-  '@decky/ui@4.8.3':
-    resolution: {integrity: sha512-Y1KciazgvKqMEVBGrWFCTGOqgVi5sHbcQNoCZRMbPpcI0U3j7udl6mkfe/NBa16oRDZ03ljS41SmrAgKAAt/pA==}
+  '@decky/ui@4.10.1':
+    resolution: {integrity: sha512-8rTqVjjXOGJw2oa5BrT1pFY9X8DVAc3E89d4ya93kq5ixK8zQF4FKxnFPYiJ/7w354mVZGdgpx1L5RmZ3Q7e+g==}
 
   '@esbuild/aix-ppc64@0.20.2':
     resolution: {integrity: sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==}
@@ -2295,7 +2295,7 @@ snapshots:
 
   '@decky/api@1.1.1': {}
 
-  '@decky/ui@4.8.3': {}
+  '@decky/ui@4.10.1': {}
 
   '@esbuild/aix-ppc64@0.20.2':
     optional: true

--- a/frontend/src/components/modals/filepicker/patches/library.ts
+++ b/frontend/src/components/modals/filepicker/patches/library.ts
@@ -47,7 +47,7 @@ export default async function libraryPatch() {
     }
 
     const unlisten = History.listen(() => {
-      if (window.SteamClient.Apps.PromptToChangeShortcut !== patch.patchedFunction) {
+      if ((window.SteamClient.Apps as any).PromptToChangeShortcut !== patch.patchedFunction) {
         rePatch();
       }
     });

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -1,5 +1,6 @@
 import { ToastNotification } from '@decky/api';
 import {
+  EUIMode,
   ModalRoot,
   Navigation,
   PanelSection,
@@ -9,7 +10,6 @@ import {
   quickAccessMenuClasses,
   showModal,
   sleep,
-  EUIMode
 } from '@decky/ui';
 import { FC, lazy } from 'react';
 import { FaDownload, FaExclamationCircle, FaPlug } from 'react-icons/fa';

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -9,6 +9,7 @@ import {
   quickAccessMenuClasses,
   showModal,
   sleep,
+  EUIMode
 } from '@decky/ui';
 import { FC, lazy } from 'react';
 import { FaDownload, FaExclamationCircle, FaPlug } from 'react-icons/fa';
@@ -30,7 +31,7 @@ import { HiddenPluginsService } from './hidden-plugins-service';
 import Logger from './logger';
 import { NotificationService } from './notification-service';
 import { InstallType, Plugin, PluginLoadType } from './plugin';
-import RouterHook, { UIMode } from './router-hook';
+import RouterHook from './router-hook';
 import { deinitSteamFixes, initSteamFixes } from './steamfixes';
 import { checkForPluginUpdates } from './store';
 import TabsHook from './tabs-hook';
@@ -205,12 +206,12 @@ class PluginLoader extends Logger {
     let registration: any;
     const uiMode = await new Promise(
       (r) =>
-        (registration = SteamClient.UI.RegisterForUIModeChanged((mode: UIMode) => {
+        (registration = SteamClient.UI.RegisterForUIModeChanged((mode: EUIMode) => {
           r(mode);
           registration.unregister();
         })),
     );
-    if (uiMode == UIMode.BigPicture) {
+    if (uiMode == EUIMode.GamePad) {
       // wait for SP window to exist before loading plugins
       while (!findSP()) {
         await sleep(100);

--- a/frontend/src/router-hook.tsx
+++ b/frontend/src/router-hook.tsx
@@ -1,4 +1,5 @@
 import {
+  EUIMode,
   ErrorBoundary,
   Patch,
   afterPatch,
@@ -7,7 +8,6 @@ import {
   findModuleByExport,
   getReactRoot,
   sleep,
-  EUIMode
 } from '@decky/ui';
 import { FC, ReactElement, ReactNode, cloneElement, createElement } from 'react';
 import type { Route } from 'react-router';

--- a/frontend/src/router-hook.tsx
+++ b/frontend/src/router-hook.tsx
@@ -7,6 +7,7 @@ import {
   findModuleByExport,
   getReactRoot,
   sleep,
+  EUIMode
 } from '@decky/ui';
 import { FC, ReactElement, ReactNode, cloneElement, createElement } from 'react';
 import type { Route } from 'react-router';
@@ -29,11 +30,6 @@ declare global {
   interface Window {
     __ROUTER_HOOK_INSTANCE: any;
   }
-}
-
-export enum UIMode {
-  BigPicture = 4,
-  Desktop = 7,
 }
 
 const isPatched = Symbol('is patched');
@@ -76,13 +72,13 @@ class RouterHook extends Logger {
       this.error('Failed to find router stack module');
     }
 
-    this.modeChangeRegistration = SteamClient.UI.RegisterForUIModeChanged((mode: UIMode) => {
+    this.modeChangeRegistration = SteamClient.UI.RegisterForUIModeChanged((mode: EUIMode) => {
       this.debug(`UI mode changed to ${mode}`);
       if (this.patchedModes.has(mode)) return;
       this.patchedModes.add(mode);
       this.debug(`Patching router for UI mode ${mode}`);
       switch (mode) {
-        case UIMode.BigPicture:
+        case EUIMode.GamePad:
           this.debug('Patching gamepad router');
           this.patchGamepadRouter();
           break;


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Update decky/ui to 4.10.1 which includes fixes for `<Menu />` in the new Steam beta.

Parent PR:
https://github.com/SteamDeckHomebrew/decky-frontend-lib/pull/119
