### PR TITLE
Fix reversed store sorting options

### DIFF
--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -68,9 +68,6 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
 
   const dropdownSortOptions = useMemo(
     (): DropdownOption[] => [
-      // ascending and descending order are the wrong way around for the alphabetical sort
-      // this is because it was initially done incorrectly for i18n and 'fixing' it would
-      // make all the translations incorrect
       { data: [SortOptions.name, SortDirections.ascending], label: t('Store.store_tabs.alph_desc') },
       { data: [SortOptions.name, SortDirections.descending], label: t('Store.store_tabs.alph_asce') },
       { data: [SortOptions.date, SortDirections.ascending], label: t('Store.store_tabs.date_asce') },

--- a/frontend/src/store.tsx
+++ b/frontend/src/store.tsx
@@ -59,7 +59,13 @@ export async function getPluginList(
 
   let query: URLSearchParams | string = new URLSearchParams();
   sort_by && query.set('sort_by', sort_by);
-  sort_direction && query.set('sort_direction', sort_direction);
+  if (sort_direction) {
+    // Backend currently interprets asc/desc the opposite way around, so invert the value
+    // to keep the UI-provided sort direction correct. Remove once backend is fixed (issue #862).
+    const backendSortDirection =
+      sort_direction === SortDirections.ascending ? SortDirections.descending : SortDirections.ascending;
+    query.set('sort_direction', backendSortDirection);
+  }
   query = '?' + String(query);
 
   let storeURL;


### PR DESCRIPTION
Please tick as appropriate:
- [X] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #862

Inverted sorting at the UI level before hitting the API.
