### PR TITLE
Update directory path to use $HOME variable in plugin info script

### DIFF
--- a/scripts/plugin-info.sh
+++ b/scripts/plugin-info.sh
@@ -2,7 +2,7 @@
 # Adapted from a script provided by Jaynator495.
 # Make sure to place in home directory, chmod +x plugin-info.sh and then run with ./plugin-info.sh
 # Define the directory to scan
-directory_to_scan="~/homebrew/plugins"
+directory_to_scan="$HOME/homebrew/plugins"
 
 # Loop through each subdirectory (one level deep)
 for dir in "$directory_to_scan"/*/; do


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

Plugin info script doesn't work as is. ~ doesn't expand to home dir when inside quotes, using $HOME does.
