### PR TITLE
feat: allow pinning plugins to top-level QAM

### DIFF
--- a/backend/decky_loader/browser.py
+++ b/backend/decky_loader/browser.py
@@ -341,6 +341,11 @@ class PluginBrowser:
             hidden_plugins.remove(name)
             self.settings.setSetting("hiddenPlugins", hidden_plugins)
 
+        pinned_plugins = self.settings.getSetting("pinnedPlugins", [])
+        if name in pinned_plugins:
+            pinned_plugins.remove(name)
+            self.settings.setSetting("pinnedPlugins", pinned_plugins)
+
         plugin_order = self.settings.getSetting("pluginOrder", [])
 
         if name in plugin_order:

--- a/backend/decky_loader/locales/en-US.json
+++ b/backend/decky_loader/locales/en-US.json
@@ -126,12 +126,14 @@
         "freeze": "Freeze updates",
         "hide": "Quick access: Hide",
         "no_plugin": "No plugins installed!",
+        "pin": "Pin directly to Quick Access Menu",
         "plugin_actions": "Plugin Actions",
         "reinstall": "Reinstall",
         "reload": "Reload",
         "show": "Quick access: Show",
         "unfreeze": "Allow updates",
         "uninstall": "Uninstall",
+        "unpin": "Unpin from Quick Access Menu",
         "update_all_one": "Update 1 plugin",
         "update_all_other": "Update {{count}} plugins",
         "update_to": "Update to {{name}}",
@@ -140,6 +142,7 @@
     },
     "PluginListLabel": {
         "hidden": "Hidden from the quick access menu",
+        "pinned": "Pinned directly to Quick Access Menu",
         "disabled": "Plugin disabled"
     },
     "PluginLoader": {

--- a/frontend/src/components/DeckyState.tsx
+++ b/frontend/src/components/DeckyState.tsx
@@ -12,6 +12,7 @@ interface PublicDeckyState {
   pluginOrder: string[];
   frozenPlugins: string[];
   hiddenPlugins: string[];
+  pinnedPlugins: string[];
   activePlugin: Plugin | null;
   updates: PluginUpdateMapping | null;
   hasLoaderUpdate?: boolean;
@@ -33,6 +34,7 @@ export class DeckyState {
   private _pluginOrder: string[] = [];
   private _frozenPlugins: string[] = [];
   private _hiddenPlugins: string[] = [];
+  private _pinnedPlugins: string[] = [];
   private _activePlugin: Plugin | null = null;
   private _updates: PluginUpdateMapping | null = null;
   private _hasLoaderUpdate: boolean = false;
@@ -51,6 +53,7 @@ export class DeckyState {
       pluginOrder: this._pluginOrder,
       frozenPlugins: this._frozenPlugins,
       hiddenPlugins: this._hiddenPlugins,
+      pinnedPlugins: this._pinnedPlugins,
       activePlugin: this._activePlugin,
       updates: this._updates,
       hasLoaderUpdate: this._hasLoaderUpdate,
@@ -90,6 +93,11 @@ export class DeckyState {
 
   setHiddenPlugins(hiddenPlugins: string[]) {
     this._hiddenPlugins = hiddenPlugins;
+    this.notifyUpdate();
+  }
+
+  setPinnedPlugins(pinnedPlugins: string[]) {
+    this._pinnedPlugins = pinnedPlugins;
     this.notifyUpdate();
   }
 

--- a/frontend/src/components/PinnedPluginView.tsx
+++ b/frontend/src/components/PinnedPluginView.tsx
@@ -1,0 +1,41 @@
+import { ErrorBoundary, Focusable, staticClasses } from '@decky/ui';
+import { CSSProperties, FC } from 'react';
+import { FaPlug } from 'react-icons/fa';
+
+import { useDeckyState } from './DeckyState';
+import { useQuickAccessVisible } from './QuickAccessVisibleState';
+
+interface PinnedPluginViewProps {
+  name: string;
+  iconOnly?: boolean;
+}
+
+const titleStyles: CSSProperties = {
+  display: 'flex',
+  paddingRight: '16px',
+  position: 'sticky',
+  top: '0px',
+};
+
+const PinnedPluginView: FC<PinnedPluginViewProps> = ({ name, iconOnly }) => {
+  const { plugins } = useDeckyState();
+  const visible = useQuickAccessVisible();
+  const plugin = plugins.find((p) => p.name === name);
+
+  if (iconOnly) {
+    return <>{plugin?.icon ?? <FaPlug />}</>;
+  }
+
+  return (
+    <Focusable>
+      <Focusable className={staticClasses.Title} style={titleStyles}>
+        {plugin?.titleView ?? <div style={{ flex: 0.9 }}>{plugin?.name ?? name}</div>}
+      </Focusable>
+      <div style={{ height: '100%', paddingTop: '16px' }}>
+        <ErrorBoundary>{plugin?.content && (visible || plugin.alwaysRender) && plugin.content}</ErrorBoundary>
+      </div>
+    </Focusable>
+  );
+};
+
+export default PinnedPluginView;

--- a/frontend/src/components/PluginView.tsx
+++ b/frontend/src/components/PluginView.tsx
@@ -13,6 +13,7 @@ const PluginView: FC = () => {
     plugins,
     disabledPlugins,
     hiddenPlugins,
+    pinnedPlugins,
     updates,
     activePlugin,
     pluginOrder,
@@ -28,8 +29,8 @@ const PluginView: FC = () => {
     return [...plugins]
       .sort((a, b) => pluginOrder.indexOf(a.name) - pluginOrder.indexOf(b.name))
       .filter((p) => p.content)
-      .filter(({ name }) => !hiddenPlugins.includes(name));
-  }, [plugins, pluginOrder, hiddenPlugins]);
+      .filter(({ name }) => !hiddenPlugins.includes(name) && !pinnedPlugins.includes(name));
+  }, [plugins, pluginOrder, hiddenPlugins, pinnedPlugins]);
 
   const numberOfHidden = hiddenPlugins.filter((name) => !!plugins.find((p) => p.name === name)).length;
 

--- a/frontend/src/components/modals/PluginUninstallModal.tsx
+++ b/frontend/src/components/modals/PluginUninstallModal.tsx
@@ -33,6 +33,7 @@ const PluginUninstallModal: FC<PluginUninstallModalProps> = ({
         // we invalidate here so if you re-install it, you won't have an out-of-date hidden filter
         await DeckyPluginLoader.frozenPluginsService.invalidate();
         await DeckyPluginLoader.hiddenPluginsService.invalidate();
+        await DeckyPluginLoader.pinnedPluginsService.invalidate();
         closeModal?.();
       }}
       bOKDisabled={uninstalling}

--- a/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/PluginListLabel.tsx
@@ -1,16 +1,17 @@
 import { FC } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FaBan, FaEyeSlash, FaLock } from 'react-icons/fa';
+import { FaBan, FaEyeSlash, FaLock, FaThumbtack } from 'react-icons/fa';
 
 interface PluginListLabelProps {
   frozen: boolean;
   hidden: boolean;
+  pinned: boolean;
   disabled: boolean;
   name: string;
   version?: string;
 }
 
-const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, version, disabled }) => {
+const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, pinned, version, disabled }) => {
   const { t } = useTranslation();
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
@@ -42,6 +43,20 @@ const PluginListLabel: FC<PluginListLabelProps> = ({ name, frozen, hidden, versi
         >
           <FaEyeSlash />
           {t('PluginListLabel.hidden')}
+        </div>
+      )}
+      {pinned && (
+        <div
+          style={{
+            fontSize: '0.8rem',
+            color: '#dcdedf',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '10px',
+          }}
+        >
+          <FaThumbtack />
+          {t('PluginListLabel.pinned')}
         </div>
       )}
       {disabled && (

--- a/frontend/src/components/settings/pages/plugin_list/index.tsx
+++ b/frontend/src/components/settings/pages/plugin_list/index.tsx
@@ -44,6 +44,9 @@ type PluginTableData = PluginData & {
   hidden: boolean;
   onHide(): void;
   onShow(): void;
+  pinned: boolean;
+  onPin(): void;
+  onUnpin(): void;
   isDeveloper: boolean;
 };
 
@@ -57,8 +60,22 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
     return null;
   }
 
-  const { name, update, version, onHide, onShow, hidden, onFreeze, onUnfreeze, frozen, isDeveloper, disabled } =
-    props.entry.data;
+  const {
+    name,
+    update,
+    version,
+    onHide,
+    onShow,
+    hidden,
+    onFreeze,
+    onUnfreeze,
+    frozen,
+    onPin,
+    onUnpin,
+    pinned,
+    isDeveloper,
+    disabled,
+  } = props.entry.data;
 
   const showCtxMenu = (e: MouseEvent | GamepadEvent) => {
     showContextMenu(
@@ -109,6 +126,13 @@ function PluginInteractables(props: { entry: ReorderableEntry<PluginTableData> }
             <MenuItem onSelected={onShow}>{t('PluginListIndex.show')}</MenuItem>
           ) : (
             <MenuItem onSelected={onHide}>{t('PluginListIndex.hide')}</MenuItem>
+          ))}
+        {!disabled &&
+          !hidden &&
+          (pinned ? (
+            <MenuItem onSelected={onUnpin}>{t('PluginListIndex.unpin')}</MenuItem>
+          ) : (
+            <MenuItem onSelected={onPin}>{t('PluginListIndex.pin')}</MenuItem>
           ))}
         {frozen ? (
           <MenuItem onSelected={onUnfreeze}>{t('PluginListIndex.unfreeze')}</MenuItem>
@@ -170,8 +194,16 @@ type PluginData = {
 };
 
 export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
-  const { installedPlugins, disabledPlugins, updates, pluginOrder, setPluginOrder, frozenPlugins, hiddenPlugins } =
-    useDeckyState();
+  const {
+    installedPlugins,
+    disabledPlugins,
+    updates,
+    pluginOrder,
+    setPluginOrder,
+    frozenPlugins,
+    hiddenPlugins,
+    pinnedPlugins,
+  } = useDeckyState();
 
   const [_, setPluginOrderSetting] = useSetting<string[]>(
     'pluginOrder',
@@ -186,12 +218,14 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
   const [pluginEntries, setPluginEntries] = useState<ReorderableEntry<PluginTableData>[]>([]);
   const hiddenPluginsService = DeckyPluginLoader.hiddenPluginsService;
   const frozenPluginsService = DeckyPluginLoader.frozenPluginsService;
+  const pinnedPluginsService = DeckyPluginLoader.pinnedPluginsService;
 
   useEffect(() => {
     setPluginEntries(
       installedPlugins.map(({ name, version }) => {
         const frozen = frozenPlugins.includes(name);
         const hidden = hiddenPlugins.includes(name);
+        const pinned = pinnedPlugins.includes(name);
 
         return {
           label: (
@@ -199,6 +233,7 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
               name={name}
               frozen={frozen}
               hidden={hidden}
+              pinned={pinned}
               version={version}
               disabled={disabledPlugins.find((p) => p.name == name) !== undefined}
             />
@@ -209,6 +244,7 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
             disabled: disabledPlugins.some((disabledPlugin) => disabledPlugin.name === name),
             frozen,
             hidden,
+            pinned,
             isDeveloper,
             version,
             update: updates?.get(name),
@@ -216,11 +252,13 @@ export default function PluginList({ isDeveloper }: { isDeveloper: boolean }) {
             onUnfreeze: () => frozenPluginsService.update(frozenPlugins.filter((pluginName) => name !== pluginName)),
             onHide: () => hiddenPluginsService.update([...hiddenPlugins, name]),
             onShow: () => hiddenPluginsService.update(hiddenPlugins.filter((pluginName) => name !== pluginName)),
+            onPin: () => pinnedPluginsService.update([...pinnedPlugins, name]),
+            onUnpin: () => pinnedPluginsService.update(pinnedPlugins.filter((pluginName) => name !== pluginName)),
           },
         };
       }),
     );
-  }, [installedPlugins, updates, hiddenPlugins, disabledPlugins]);
+  }, [installedPlugins, updates, hiddenPlugins, pinnedPlugins, disabledPlugins]);
 
   if (installedPlugins.length === 0) {
     return (

--- a/frontend/src/pinned-plugins-service.tsx
+++ b/frontend/src/pinned-plugins-service.tsx
@@ -1,0 +1,34 @@
+import { DeckyState } from './components/DeckyState';
+import { getSetting, setSetting } from './utils/settings';
+
+/**
+ * A Service class for managing the state and actions related to the pinned plugins feature.
+ *
+ * It's mostly responsible for sending setting updates to the server and keeping the local state in sync.
+ */
+export class PinnedPluginsService {
+  constructor(private deckyState: DeckyState) {}
+
+  init() {
+    getSetting<string[]>('pinnedPlugins', []).then((pinnedPlugins) => {
+      this.deckyState.setPinnedPlugins(pinnedPlugins);
+    });
+  }
+
+  /**
+   * Sends the new pinned plugins list to the server and persists it locally in the decky state
+   *
+   * @param pinnedPlugins The new list of pinned plugins
+   */
+  async update(pinnedPlugins: string[]) {
+    await setSetting('pinnedPlugins', pinnedPlugins);
+    this.deckyState.setPinnedPlugins(pinnedPlugins);
+  }
+
+  /**
+   * Refreshes the state of pinned plugins in the local state
+   */
+  async invalidate() {
+    this.deckyState.setPinnedPlugins(await getSetting('pinnedPlugins', []));
+  }
+}

--- a/frontend/src/plugin-loader.tsx
+++ b/frontend/src/plugin-loader.tsx
@@ -23,6 +23,7 @@ import PluginDisableModal from './components/modals/PluginDisableModal';
 import PluginInstallModal from './components/modals/PluginInstallModal';
 import PluginUninstallModal from './components/modals/PluginUninstallModal';
 import NotificationBadge from './components/NotificationBadge';
+import PinnedPluginView from './components/PinnedPluginView';
 import PluginView from './components/PluginView';
 import { useQuickAccessVisible } from './components/QuickAccessVisibleState';
 import WithSuspense from './components/WithSuspense';
@@ -31,6 +32,7 @@ import { FrozenPluginService } from './frozen-plugins-service';
 import { HiddenPluginsService } from './hidden-plugins-service';
 import Logger from './logger';
 import { NotificationService } from './notification-service';
+import { PinnedPluginsService } from './pinned-plugins-service';
 import { DisabledPlugin, InstallType, Plugin, PluginLoadType } from './plugin';
 import RouterHook from './router-hook';
 import { deinitSteamFixes, initSteamFixes } from './steamfixes';
@@ -38,6 +40,7 @@ import { checkForPluginUpdates } from './store';
 import TabsHook from './tabs-hook';
 import Toaster from './toaster';
 import { getVersionInfo } from './updater';
+import { pinnedPluginTabId } from './utils/pinned-tab-id';
 import { getSetting, setSetting } from './utils/settings';
 import TranslationHelper, { TranslationClass } from './utils/TranslationHelper';
 
@@ -77,7 +80,10 @@ class PluginLoader extends Logger {
 
   public frozenPluginsService = new FrozenPluginService(this.deckyState);
   public hiddenPluginsService = new HiddenPluginsService(this.deckyState);
+  public pinnedPluginsService = new PinnedPluginsService(this.deckyState);
   public notificationService = new NotificationService(this.deckyState);
+
+  private pinnedTabIds = new Map<string, number>();
 
   private reloadLock: boolean = false;
   // stores a list of plugin names which requested to be reloaded
@@ -125,6 +131,8 @@ class PluginLoader extends Logger {
         </DeckyStateContextProvider>
       ),
     });
+
+    this.deckyState.eventBus.addEventListener('update', this.syncPinnedTabs);
 
     this.routerHook.addRoute('/decky/store', () => (
       <DeckyStateContextProvider deckyState={this.deckyState}>
@@ -361,10 +369,12 @@ class PluginLoader extends Logger {
 
     this.frozenPluginsService.init();
     this.hiddenPluginsService.init();
+    this.pinnedPluginsService.init();
     this.notificationService.init();
   }
 
   public deinit() {
+    this.deckyState.eventBus.removeEventListener('update', this.syncPinnedTabs);
     this.routerHook.removeRoute('/decky/store');
     this.routerHook.removeRoute('/decky/settings');
     deinitSteamFixes();
@@ -374,6 +384,44 @@ class PluginLoader extends Logger {
     this.toaster.deinit();
     this.errorBoundaryHook.deinit();
   }
+
+  private syncPinnedTabs = () => {
+    const { pinnedPlugins, pluginOrder } = this.deckyState.publicState();
+    const orderedPinned = [...pinnedPlugins].sort((a, b) => pluginOrder.indexOf(a) - pluginOrder.indexOf(b));
+    const desired = new Set(orderedPinned);
+
+    const currentOrder = [...this.pinnedTabIds.keys()].filter((name) => desired.has(name));
+    const desiredOrder = orderedPinned.filter((name) => this.pinnedTabIds.has(name));
+    const orderChanged = currentOrder.join('\0') !== desiredOrder.join('\0');
+
+    for (const name of [...this.pinnedTabIds.keys()]) {
+      if (!desired.has(name) || orderChanged) {
+        const id = this.pinnedTabIds.get(name)!;
+        this.tabsHook.removeById(id);
+        this.pinnedTabIds.delete(name);
+      }
+    }
+
+    for (const name of orderedPinned) {
+      if (this.pinnedTabIds.has(name)) continue;
+      const id = pinnedPluginTabId(name, new Set(this.pinnedTabIds.values()));
+      this.pinnedTabIds.set(name, id);
+      this.tabsHook.add({
+        id,
+        title: null,
+        content: (
+          <DeckyStateContextProvider deckyState={this.deckyState}>
+            <PinnedPluginView name={name} />
+          </DeckyStateContextProvider>
+        ),
+        icon: (
+          <DeckyStateContextProvider deckyState={this.deckyState}>
+            <PinnedPluginView name={name} iconOnly />
+          </DeckyStateContextProvider>
+        ),
+      });
+    }
+  };
 
   public doDisablePlugin(name: string) {
     const plugin = this.plugins.find((plugin) => plugin.name === name);

--- a/frontend/src/tabs-hook.tsx
+++ b/frontend/src/tabs-hook.tsx
@@ -20,7 +20,7 @@ declare global {
 }
 
 interface Tab {
-  id: QuickAccessTab | number;
+  id: QuickAccessTab | number | string;
   title: any;
   content: any;
   icon: any;
@@ -92,38 +92,48 @@ class TabsHook extends Logger {
     this.tabs.push(tab);
   }
 
-  removeById(id: number) {
+  removeById(id: QuickAccessTab | number | string) {
     this.debug('Removing tab', id);
     this.tabs = this.tabs.filter((tab) => tab.id !== id);
   }
 
   render(existingTabs: any[], visible: boolean) {
-    let deckyTabAmount = existingTabs.reduce((prev: any, cur: any) => (cur.decky ? prev + 1 : prev), 0);
-    if (deckyTabAmount == this.tabs.length) {
-      for (let tab of existingTabs) {
-        if (tab?.decky) {
-          if (tab?.qAMVisibilitySetter) {
-            tab?.qAMVisibilitySetter(visible);
-          } else {
-            tab.initialVisibility = visible;
-          }
-        }
+    const existing = new Map<unknown, any>();
+    for (let i = existingTabs.length - 1; i >= 0; i--) {
+      if (existingTabs[i]?.decky) {
+        existing.set(existingTabs[i].key, existingTabs[i]);
+        existingTabs.splice(i, 1);
       }
-      return;
     }
-    for (const { title, icon, content, id } of this.tabs) {
-      const tab: any = {
-        key: id,
-        title,
-        tab: icon,
-        decky: true,
-        initialVisibility: visible,
-      };
-      tab.panel = (
-        <ErrorBoundary>
-          <QuickAccessVisibleStateProvider tab={tab}>{content}</QuickAccessVisibleStateProvider>
-        </ErrorBoundary>
-      );
+
+    const ordered = [...this.tabs].sort((a, b) => {
+      if (a.id === QuickAccessTab.Decky) return 1;
+      if (b.id === QuickAccessTab.Decky) return -1;
+      return 0;
+    });
+
+    for (const { title, icon, content, id } of ordered) {
+      let tab = existing.get(id);
+      if (tab) {
+        if (tab.qAMVisibilitySetter) {
+          tab.qAMVisibilitySetter(visible);
+        } else {
+          tab.initialVisibility = visible;
+        }
+      } else {
+        tab = {
+          key: id,
+          title,
+          tab: icon,
+          decky: true,
+          initialVisibility: visible,
+        };
+        tab.panel = (
+          <ErrorBoundary>
+            <QuickAccessVisibleStateProvider tab={tab}>{content}</QuickAccessVisibleStateProvider>
+          </ErrorBoundary>
+        );
+      }
       existingTabs.push(tab);
     }
   }

--- a/frontend/src/utils/pinned-tab-id.ts
+++ b/frontend/src/utils/pinned-tab-id.ts
@@ -1,0 +1,17 @@
+// QAM tab ids are reserved by Steam in the low range and by Decky at 999.
+// Generate a stable id per plugin name that sits between the two, so a pinned
+// plugin tab appears above the Decky tab in the QAM.
+const MIN_ID = 100;
+const MAX_ID = 998;
+
+export function pinnedPluginTabId(name: string, reserved: Set<number>): number {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
+  }
+  let id = MIN_ID + (Math.abs(hash) % (MAX_ID - MIN_ID + 1));
+  while (reserved.has(id)) {
+    id = id + 1 > MAX_ID ? MIN_ID : id + 1;
+  }
+  return id;
+}


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

If you're wanting to update a translation or add a new one, please use the weblate page: https://weblate.werwolv.net/projects/decky/

# Description

This fixes issue: #887.

Adds an option to pin any installed plugin from the Decky tab up to the top level of the Quick Access Menu, so it gets its own QAM tab above the Decky plug icon instead of being nested under it. Use case from the issue: jumping straight to a music controller plugin without going through the Decky tab.

- New per-plugin **Pin directly to Quick Access Menu** / **Unpin from Quick Access Menu** action in the plugin list context menu (Decky → gear → Plugins → ⋯).
- Pinned plugins get their own QAM tab placed above the Decky tab; the tab renders the plugin's `titleView` (or its name) as a heading, then its content — matching the inner Decky tab plugin view.
- Pinned plugins are hidden from the Decky tab's plugin list so the UI isn't duplicated.
- Tab ordering respects the existing `pluginOrder` from the plugin list (drag-reorder applies on next QAM open — same lifecycle as every other tab change).
- State persisted under a new `pinnedPlugins` setting; cleared on uninstall in `cleanup_plugin_settings`, and the frontend service is invalidated from the uninstall modal alongside the existing frozen/hidden invalidations.
- `tabs-hook` extended to support tab removal and stable ordering relative to the Decky tab (previously it was add-only).

## Implementation notes

- New `PinnedPluginsService` mirrors the existing `HiddenPluginsService` / `FrozenPluginService` pattern (settings get/set + invalidate).
- `DeckyState` gains a `pinnedPlugins: string[]` field with setter + publicState entry.
- `PluginLoader` subscribes to deckyState updates and reconciles QAM tabs via `tabsHook`. Each pinned plugin gets a stable numeric tab id in `[100, 998]` derived from its name (with collision rehash) so it sits between Steam's built-in tabs and `QuickAccessTab.Decky` (999).
- `PinnedPluginView` resolves the plugin via `useDeckyState`, so plugin reloads/dev hot-reloads don't strand the tab; while the plugin is unloaded the tab is just empty rather than crashing.
- Only `en-US.json` strings are added — other locales fall back until Weblate contributors translate, matching how prior strings like `freeze`/`hide` were introduced.

## Test plan

Verified end-to-end on a ROG Ally X running Bazzite + dev decky-loader. Existing decky behaviors (hide, freeze, reorder, uninstall) still work; build/typecheck/prettier all clean.

- [x] Pin a plugin from Decky → gear → Plugins; close/reopen QAM → plugin appears as its own tab above the Decky plug icon with its name as a heading
- [x] Pinned plugin no longer appears in the Decky tab's plugin list
- [x] Unpin the same plugin → standalone tab disappears, plugin returns to the Decky tab list
- [x] Drag-reorder plugins in settings → tab order in QAM reflects the new order on next open
- [x] Uninstall a pinned plugin → no orphan tab on next launch; `pinnedPlugins` setting cleared
- [x] Pin multiple plugins → all stack above Decky in the configured order
- [x] Plugin label in settings shows the "Pinned" indicator while pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)