### PR TITLE
feat: add Linux arm64 build workflow

### DIFF
--- a/.github/workflows/build-linux-arm64.yml
+++ b/.github/workflows/build-linux-arm64.yml
@@ -1,0 +1,13 @@
+name: Builder (Linux arm64)
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      arch: arm64
+      output_name: PluginLoader-arm64

--- a/.github/workflows/build-linux-x86_64.yml
+++ b/.github/workflows/build-linux-x86_64.yml
@@ -1,0 +1,13 @@
+name: Builder (Linux x86_64)
+
+on:
+  push:
+  pull_request:
+  workflow_call:
+
+jobs:
+  build:
+    uses: ./.github/workflows/build-linux.yml
+    with:
+      arch: x86_64
+      output_name: PluginLoader

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,16 +1,21 @@
-name: Builder
+name: Builder (Linux)
 
 on:
-  push:
-  pull_request:
   workflow_call:
-  # schedule:
-  #   - cron: '0 13 * * *' # run at 1 PM UTC
+    inputs:
+      arch:
+        description: Architecture to build for (x86_64, arm64)
+        type: string
+        default: x86_64
+      output_name:
+        description: Output name
+        type: string
+        default: PluginLoader
 
 jobs:
   build:
-    name: Build PluginLoader
-    runs-on: ubuntu-22.04
+    name: Build ${{ inputs.output_name }} (Linux ${{ inputs.arch }})
+    runs-on: ${{ inputs.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-22.04' }}
 
     steps:
     - name: Checkout 🧰
@@ -55,15 +60,19 @@ jobs:
         poetry dynamic-versioning 
         pyinstaller pyinstaller.spec
 
+    - name: Rename artifact 🛠️
+      if: ${{ inputs.output_name != 'PluginLoader' }}
+      run: mv ./backend/dist/PluginLoader ./backend/dist/${{ inputs.output_name }}
+
     - name: Upload package artifact ⬆️
       if: ${{ !env.ACT }}
       uses: actions/upload-artifact@v4
       with:
-        name: PluginLoader
-        path: ./backend/dist/PluginLoader
+        name: ${{ inputs.output_name }}
+        path: ./backend/dist/${{ inputs.output_name }}
 
     - name: Download package artifact locally
       if: ${{ env.ACT }}
       uses: actions/upload-artifact@v4
       with:
-        path: ./backend/dist/PluginLoader
+        path: ./backend/dist/${{ inputs.output_name }}

--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -1,4 +1,4 @@
-name: Builder Win
+name: Builder (Windows)
 
 on:
   push:
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   build-win:
-    name: Build PluginLoader for Win
+    name: Build PluginLoader (Windows x86_64)
     runs-on: windows-2022
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,18 +123,24 @@ jobs:
 
   build:
     name: Build tagged artifact
-    uses: ./.github/workflows/build.yml
+    uses: ./.github/workflows/build-linux-x86_64.yml
+    needs: [create_tag]
+
+  build_arm64:
+    name: Build tagged artifact (arm64)
+    uses: ./.github/workflows/build-linux-arm64.yml
     needs: [create_tag]
 
   release:
-    name: Release tagged artifact
+    name: Release tagged artifacts
     runs-on: ubuntu-22.04
-    needs: [create_tag, build]
+    needs: [create_tag, build, build_arm64]
     steps:
-      - name: Fetch package artifact ⬇️
+      - name: Fetch package artifacts ⬇️
         uses: actions/download-artifact@v4
         with:
-          name: PluginLoader
+          pattern: PluginLoader*
+          merge-multiple: true
 
       - name: Pre-release 📦
         if: github.event.inputs.release == 'prerelease'
@@ -142,7 +148,9 @@ jobs:
         with:
           name: Prerelease ${{ needs.create_tag.outputs.tag_name }}
           tag_name: ${{ needs.create_tag.outputs.tag_name }}
-          files: ./PluginLoader
+          files: |
+            ./PluginLoader
+            ./PluginLoader-arm64
           prerelease: true
           generate_release_notes: true
       - name: Release 📦
@@ -151,6 +159,8 @@ jobs:
         with:
           name: Release ${{ needs.create_tag.outputs.tag_name }}
           tag_name: ${{ needs.create_tag.outputs.tag_name }}
-          files: ./PluginLoader
+          files: |
+            ./PluginLoader
+            ./PluginLoader-arm64
           prerelease: false
           generate_release_notes: true

--- a/backend/decky_loader/localplatform/localplatform.py
+++ b/backend/decky_loader/localplatform/localplatform.py
@@ -3,6 +3,9 @@ import platform, os
 ON_WINDOWS = platform.system() == "Windows"
 ON_LINUX = not ON_WINDOWS
 
+# macOS reports arm64, Linux reports aarch64
+ON_ARM64 = platform.machine() == "arm64" or platform.machine() == "aarch64" 
+
 if ON_WINDOWS:
     from .localplatformwin import *
     from . import localplatformwin as localplatform

--- a/backend/decky_loader/updater.py
+++ b/backend/decky_loader/updater.py
@@ -6,7 +6,7 @@ from os import getcwd, path, remove
 from typing import TYPE_CHECKING, List, TypedDict
 if TYPE_CHECKING:
     from .main import PluginManager
-from .localplatform.localplatform import chmod, service_restart, service_stop, ON_LINUX, ON_WINDOWS, get_keep_systemd_service, get_selinux
+from .localplatform.localplatform import chmod, service_restart, service_stop, ON_LINUX, ON_WINDOWS, ON_ARM64, get_keep_systemd_service, get_selinux
 import shutil
 from typing import List, TYPE_CHECKING, TypedDict
 import zipfile
@@ -138,8 +138,35 @@ class Updater:
                 pass
             await sleep(60 * 60 * 6) # 6 hours
 
+    def get_remote_binary_name(self):
+        """
+            The binaries on GitHub contain an extra part in their name to denote their architecture
+            
+            For example:
+                Windows: PluginLoader.exe
+                Linux (x86_64): PluginLoader
+                Linux (arm64): PluginLoader-arm64
+        """
+        binary_name = "PluginLoader"
+
+        if ON_ARM64 and ON_LINUX:
+            binary_name += "-arm64"
+
+        if ON_WINDOWS:
+            binary_name += ".exe"
+
+        return binary_name
+    
+    def get_local_binary_name(self):
+        binary_name = "PluginLoader"
+
+        if ON_WINDOWS:
+            binary_name += ".exe"
+
+        return binary_name
+
     async def download_decky_binary(self, download_url: str, version: str, is_zip: bool = False, size_in_bytes: int | None = None):
-        download_filename = "PluginLoader" if ON_LINUX else "PluginLoader.exe"
+        download_filename = self.get_local_binary_name()
         download_temp_filename = download_filename + ".new"
 
         if size_in_bytes == None:
@@ -196,10 +223,10 @@ class Updater:
         version = self.remoteVer["tag_name"]
         download_url = None
         size_in_bytes = None
-        download_filename = "PluginLoader" if ON_LINUX else "PluginLoader.exe"
+        remote_binary_name = self.get_remote_binary_name()
 
         for x in self.remoteVer["assets"]:
-            if x["name"] == download_filename:
+            if x["name"] == remote_binary_name:
                 download_url = x["browser_download_url"]
                 size_in_bytes = x["size"]
                 break
@@ -270,10 +297,16 @@ class Updater:
                 works = await res.json()
         #Iterate over the workflow_run to get the two builds if they exists
         for work in works['workflow_runs']:
-            if ON_WINDOWS and work['name'] == 'Builder Win':
+            # Windows x86_64
+            if ON_WINDOWS and work['name'] == 'Builder (Windows)' or work['name'] == 'Builder Win':
                 down_id=work['id']
                 break
-            elif ON_LINUX and work['name'] == 'Builder':
+            # Linux arm64
+            elif ON_LINUX and ON_ARM64 and work['name'] == 'Builder (Linux arm64)':
+                down_id=work['id']
+                break
+            # Linux x86_64
+            elif ON_LINUX and work['name'] == 'Builder (Linux x86_64)' or work['name'] == 'Builder':
                 down_id=work['id']
                 break
         if down_id != '':


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description

This adds an arm64 build step to the Actions workflows

Existing x86_64 Linux builds still get output to "PluginLoader", arm64 builds become "PluginLoader-arm64"

Seems like a good time with the Steam Frame on the horizon and Steam arm64 being available publicly (already being used on handhelds w ROCKNIX)
