### PR TITLE
Small visual fixes

### DIFF
--- a/frontend/src/components/settings/pages/general/Updater.tsx
+++ b/frontend/src/components/settings/pages/general/Updater.tsx
@@ -1,4 +1,4 @@
-import { Carousel, DialogButton, Field, Focusable, ProgressBarWithInfo, Spinner, findSP, showModal } from '@decky/ui';
+import { Carousel, DialogButton, Field, Focusable, ProgressBarWithInfo, Spinner, findSP, gamepadDialogClasses, showModal } from '@decky/ui';
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaExclamation } from 'react-icons/fa';
@@ -153,13 +153,23 @@ export default function UpdaterSettings() {
                 : t('Updater.updates.install_button')}
           </DialogButton>
         ) : (
-          <ProgressBarWithInfo
-            layout="inline"
-            bottomSeparator="none"
-            nProgress={updateProgress}
-            indeterminate={reloading}
-            sOperationText={reloading ? t('Updater.updates.reloading') : t('Updater.updates.updating')}
-          />
+          <div id="decky-hide-left">
+            <style>
+              {`
+              ${/* @ts-ignore */ ""}
+              #decky-hide-left .${gamepadDialogClasses.FieldLeftColumn as unknown as string} {
+                display: none;
+              }
+              `}
+            </style>
+            <ProgressBarWithInfo
+              layout="inline"
+              bottomSeparator="none"
+              nProgress={updateProgress}
+              indeterminate={reloading}
+              sOperationText={reloading ? t('Updater.updates.reloading') : t('Updater.updates.updating')}
+            />
+          </div>
         )}
       </Field>
       {versionInfo?.remote && versionInfo?.remote?.tag_name != versionInfo?.current && (

--- a/frontend/src/components/settings/pages/general/Updater.tsx
+++ b/frontend/src/components/settings/pages/general/Updater.tsx
@@ -129,7 +129,7 @@ export default function UpdaterSettings() {
         }
         childrenContainerWidth={'fixed'}
       >
-        {updateProgress == -1 && !isLoaderUpdating ? (
+        {false && (updateProgress == -1 && !isLoaderUpdating) ? (
           <DialogButton
             disabled={!versionInfo?.updatable || checkingForUpdates}
             onClick={

--- a/frontend/src/components/settings/pages/general/Updater.tsx
+++ b/frontend/src/components/settings/pages/general/Updater.tsx
@@ -1,4 +1,14 @@
-import { Carousel, DialogButton, Field, Focusable, ProgressBarWithInfo, Spinner, findSP, gamepadDialogClasses, showModal } from '@decky/ui';
+import {
+  Carousel,
+  DialogButton,
+  Field,
+  Focusable,
+  ProgressBarWithInfo,
+  Spinner,
+  findSP,
+  gamepadDialogClasses,
+  showModal,
+} from '@decky/ui';
 import { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaExclamation } from 'react-icons/fa';
@@ -129,7 +139,7 @@ export default function UpdaterSettings() {
         }
         childrenContainerWidth={'fixed'}
       >
-        {(updateProgress == -1 && !isLoaderUpdating) ? (
+        {updateProgress == -1 && !isLoaderUpdating ? (
           <DialogButton
             disabled={!versionInfo?.updatable || checkingForUpdates}
             onClick={
@@ -156,7 +166,7 @@ export default function UpdaterSettings() {
           <div id="decky-hide-left">
             <style>
               {`
-              ${/* @ts-ignore */ ""}
+              ${/* @ts-ignore */ ''}
               #decky-hide-left .${gamepadDialogClasses.FieldLeftColumn as unknown as string} {
                 display: none;
               }

--- a/frontend/src/components/settings/pages/general/Updater.tsx
+++ b/frontend/src/components/settings/pages/general/Updater.tsx
@@ -129,7 +129,7 @@ export default function UpdaterSettings() {
         }
         childrenContainerWidth={'fixed'}
       >
-        {false && (updateProgress == -1 && !isLoaderUpdating) ? (
+        {(updateProgress == -1 && !isLoaderUpdating) ? (
           <DialogButton
             disabled={!versionInfo?.updatable || checkingForUpdates}
             onClick={

--- a/frontend/src/components/settings/pages/testing/index.tsx
+++ b/frontend/src/components/settings/pages/testing/index.tsx
@@ -1,13 +1,13 @@
 import {
-  DialogBody,
-  DialogButton,
-  DialogControlsSection,
-  Field,
-  Focusable,
-  NavEntryPositionPreferences,
-  Navigation,
-  ProgressBar,
-  SteamSpinner,
+    DialogBody,
+    DialogButton,
+    DialogControlsSection,
+    Field,
+    Focusable,
+    NavEntryPositionPreferences,
+    Navigation,
+    ProgressBar,
+    SteamSpinner,
 } from '@decky/ui';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -84,7 +84,7 @@ export default function TestingVersionList() {
                 <Field
                   label={
                     <>
-                      {version.name} <span style={{ opacity: '50%' }}>{'#' + version.id}</span>
+                      {version.name} <span style={{ opacity: '50%', whiteSpace: 'nowrap', marginLeft: 'auto', alignSelf: 'center' }}>{'#' + version.id}</span>
                     </>
                   }
                 >

--- a/frontend/src/components/settings/pages/testing/index.tsx
+++ b/frontend/src/components/settings/pages/testing/index.tsx
@@ -1,13 +1,13 @@
 import {
-    DialogBody,
-    DialogButton,
-    DialogControlsSection,
-    Field,
-    Focusable,
-    NavEntryPositionPreferences,
-    Navigation,
-    ProgressBar,
-    SteamSpinner,
+  DialogBody,
+  DialogButton,
+  DialogControlsSection,
+  Field,
+  Focusable,
+  NavEntryPositionPreferences,
+  Navigation,
+  ProgressBar,
+  SteamSpinner,
 } from '@decky/ui';
 import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -84,7 +84,10 @@ export default function TestingVersionList() {
                 <Field
                   label={
                     <>
-                      {version.name} <span style={{ opacity: '50%', whiteSpace: 'nowrap', marginLeft: 'auto', alignSelf: 'center' }}>{'#' + version.id}</span>
+                      {version.name}{' '}
+                      <span style={{ opacity: '50%', whiteSpace: 'nowrap', marginLeft: 'auto', alignSelf: 'center' }}>
+                        {'#' + version.id}
+                      </span>
                     </>
                   }
                 >


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes the incorrect text wrapping/sizing in the testing PR menu, as well as the progressbar for Decky updates going offscreen. There is one remaining visual being, that being an incorrect gradient color for the patch notes preview, but this is an inherent issue to the Valve component and thus I didn't fix it here.

Tested on SteamOS Stable last week (the first version of stable that included the visual changes)