### PR TITLE
fix(macOS): fix macOS type checking and missing method

### DIFF
--- a/backend/decky_loader/helpers.py
+++ b/backend/decky_loader/helpers.py
@@ -93,10 +93,11 @@ user_agent = f"Decky/{get_loader_version()} (https://decky.xyz)"
 # returns the appropriate system python paths
 def get_system_pythonpaths() -> list[str]:
     try:
+        is_linux_or_mac = localplatform.ON_LINUX or localplatform.ON_MAC
         # run as normal normal user if on linux to also include user python paths
-        proc = subprocess.run(["python3" if localplatform.ON_LINUX else "python", "-c", "import sys; print('\\n'.join(x for x in sys.path if x))"],
+        proc = subprocess.run(["python3" if is_linux_or_mac else "python", "-c", "import sys; print('\\n'.join(x for x in sys.path if x))"],
         # TODO make this less insane
-                              capture_output=True, user=localplatform.localplatform._get_user_id() if localplatform.ON_LINUX else None, env={} if localplatform.ON_LINUX else None) # pyright: ignore [reportPrivateUsage]
+                              capture_output=True, user=localplatform.localplatform._get_user_id() if is_linux_or_mac else None, env={} if is_linux_or_mac else None) # pyright: ignore [reportPrivateUsage]
         
         proc.check_returncode()
 

--- a/backend/decky_loader/loader.py
+++ b/backend/decky_loader/loader.py
@@ -9,6 +9,7 @@ from typing import Any, Tuple, Dict, cast
 from aiohttp import web
 from os.path import exists
 from decky_loader.helpers import get_homebrew_path
+from decky_loader.localplatform.localplatform import ON_MAC
 from watchdog.events import RegexMatchingEventHandler, FileSystemEvent
 from watchdog.observers import Observer
 
@@ -106,6 +107,10 @@ class Loader:
 
     async def enable_reload_wait(self):
         if self.live_reload:
+            if ON_MAC:
+                self.logger.info("Hot reload is not supported on macOS")
+                return
+
             await sleep(10)
             if self.watcher and self.live_reload:
                 self.logger.info("Hot reload enabled")

--- a/backend/decky_loader/localplatform/localplatformmac.py
+++ b/backend/decky_loader/localplatform/localplatformmac.py
@@ -1,10 +1,12 @@
 from ..enums import UserType
-import os, sys
 from . import localplatformlinux
 
-# this should be public
-def _get_effective_user_id() -> int:
-    return os.geteuid()
+# NOTE: localplatformlinux has these private functions that get used in helpers.py
+def _get_user_id() -> int: # pyright: ignore[reportUnusedFunction]
+    return localplatformlinux._get_user_id() # pyright: ignore[reportPrivateUsage]
+
+def _get_effective_user_id() -> int: # pyright: ignore[reportUnusedFunction]
+    return localplatformlinux._get_effective_user_id() # pyright: ignore[reportPrivateUsage]
 
 def chown(path : str,  user : UserType = UserType.HOST_USER, recursive : bool = True) -> bool:
     return localplatformlinux.chown(path, user, recursive)
@@ -43,7 +45,7 @@ def get_username() -> str:
     return localplatformlinux.get_username()
 
 def get_privileged_path() -> str:
-    '''On Mac, privileged_path is equal to unprivileged_path'''
+    # On Mac, privileged_path is equal to unprivileged_path
     return get_unprivileged_path()
 
 def get_unprivileged_path() -> str:


### PR DESCRIPTION
Please tick as appropriate:
- [ ] I have tested this code on a steam deck or on a PC
- [X] My changes generate no new errors/warnings
- [X] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

This fixes issues related to backend macOS support

Fixes get_system_pythonpaths() in helpers.py and resolves the type checking failures

I've also found an issue with hot reloading on Mac, so I've disabled that and I'll make a PR (the fix is sorta large)
