### PR TITLE
feat: add -v/--version CLI flag to print loader version

### DIFF
--- a/backend/decky_loader/main.py
+++ b/backend/decky_loader/main.py
@@ -252,6 +252,14 @@ class PluginManager:
         run_app(self.web_app, host=get_server_host(), port=get_server_port(), loop=self.loop, access_log=None, handle_signals=True, shutdown_timeout=40)
 
 def main():
+    import argparse
+    parser = argparse.ArgumentParser(description="Decky Loader")
+    parser.add_argument("-v", "--version", action="store_true", help="Print version and exit")
+    args, _ = parser.parse_known_args()
+    if args.version:
+        print(get_loader_version())
+        sys.exit(0)
+
     setproctitle(f"Decky Loader {get_loader_version()} ({getproctitle()})")
     setthreadtitle("Decky Loader")
     if ON_WINDOWS:


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [ ] This is a bugfix/hotfix
- [x] This is a new feature

# Description

Adds `-v` / `--version` CLI flags to `main()`. When passed, prints the loader version string (e.g. `v3.1.0`) and exits with code 0.

Uses the existing `get_loader_version()` helper from `helpers.py` — no new logic needed.

Resolves #849