### PR TITLE
ci: upgrade pnpm to v10 via pnpm/action-setup

### DIFF
--- a/.github/workflows/build-win.yml
+++ b/.github/workflows/build-win.yml
@@ -37,11 +37,14 @@ jobs:
         C:\Users\runneradmin\.local\bin\poetry self add "poetry-dynamic-versioning[plugin]"
         C:\Users\runneradmin\.local\bin\poetry install --no-interaction
 
+    - name: Set up pnpm 📦
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
     - name: Install JS dependencies ⬇️
       working-directory: ./frontend
-      run: |
-        npm i -g pnpm
-        pnpm i --frozen-lockfile --dangerously-allow-all-builds
+      run: pnpm i --frozen-lockfile --dangerously-allow-all-builds
 
     - name: Build JS Frontend 🛠️
       working-directory: ./frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,14 @@ jobs:
         poetry self add "poetry-dynamic-versioning[plugin]"
         poetry install --no-interaction
 
+    - name: Set up pnpm 📦
+      uses: pnpm/action-setup@v4
+      with:
+        version: 10
+
     - name: Install JS dependencies ⬇️
       working-directory: ./frontend
-      run: |
-        npm i -g pnpm
-        pnpm i --frozen-lockfile --dangerously-allow-all-builds
+      run: pnpm i --frozen-lockfile --dangerously-allow-all-builds
 
     - name: Build JS Frontend 🛠️
       working-directory: ./frontend

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,11 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4 # Check out the repository first.
 
+      - name: Set up pnpm 📦
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install TypeScript dependencies
         working-directory: frontend
-        run: |
-          npm i -g pnpm
-          pnpm i --frozen-lockfile --dangerously-allow-all-builds
+        run: pnpm i --frozen-lockfile --dangerously-allow-all-builds
 
       - name: Run prettier (TypeScript)
         working-directory: frontend

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -31,11 +31,14 @@ jobs:
         working-directory: backend
         run: poetry install --no-interaction
 
+      - name: Set up pnpm 📦
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
       - name: Install TypeScript dependencies
         working-directory: frontend
-        run: |
-          npm i -g pnpm
-          pnpm i --frozen-lockfile --dangerously-allow-all-builds
+        run: pnpm i --frozen-lockfile --dangerously-allow-all-builds
 
       - name: Run pyright (Python)
         uses: jakebailey/pyright-action@v1

--- a/backend/decky_loader/localplatform/localplatformmac.py
+++ b/backend/decky_loader/localplatform/localplatformmac.py
@@ -1,9 +1,9 @@
 from ..enums import UserType
-import os
+import os, sys
 from . import localplatformlinux
 
 # this should be public
-def _get_effective_user_id() -> int: # pyright: ignore [reportUnusedFunction]
+def _get_effective_user_id() -> int:
     return os.geteuid()
 
 def chown(path : str,  user : UserType = UserType.HOST_USER, recursive : bool = True) -> bool:

--- a/backend/decky_loader/localplatform/localplatformmac.py
+++ b/backend/decky_loader/localplatform/localplatformmac.py
@@ -1,9 +1,9 @@
 from ..enums import UserType
-import os, sys
+import os
 from . import localplatformlinux
 
 # this should be public
-def _get_effective_user_id() -> int:
+def _get_effective_user_id() -> int: # pyright: ignore [reportUnusedFunction]
     return os.geteuid()
 
 def chown(path : str,  user : UserType = UserType.HOST_USER, recursive : bool = True) -> bool:


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [x] This is a new feature

# Description

pnpm v9.x reached end-of-life on 2026-04-30. This replaces `npm i -g pnpm` with the official `pnpm/action-setup@v4` action pinned to v10 across all four CI workflows (`build`, `build-win`, `typecheck`, `lint`).

The existing lockfile (`lockfileVersion: '9.0'`) is compatible with pnpm v10 — no lockfile regeneration needed.

## Additional fix

Also resolves the two backend `Type Check` (pyright) failures introduced by Mac support (#913) in `localplatformmac.py`:
- Removed the unused `sys` import (`reportUnusedImport`)
- Suppressed `reportUnusedFunction` on `_get_effective_user_id`, which is only referenced externally via `helpers.py`

Resolves #932
Fixes #913