### PR TITLE
fix: ignore whitespace in store plugin search

### DIFF
--- a/frontend/src/components/store/Store.tsx
+++ b/frontend/src/components/store/Store.tsx
@@ -20,6 +20,10 @@ import PluginCard from './PluginCard';
 
 const logger = new Logger('Store');
 
+// Normalize a string for searching: lowercase and strip all whitespace so that
+// queries like "tab master" match plugins named "tabmaster" (see issue #622).
+const normalizeForSearch = (value: string): string => value.toLowerCase().replace(/\s+/g, '');
+
 const StorePage: FC<{}> = () => {
   const [currentTabRoute, setCurrentTabRoute] = useState<string>('browse');
   const [pluginCount, setPluginCount] = useState<number | null>(null);
@@ -231,11 +235,12 @@ const BrowseTab: FC<{ setPluginCount: Dispatch<SetStateAction<number | null>> }>
         ) : (
           pluginList
             .filter((plugin: StorePlugin) => {
+              const query = normalizeForSearch(searchFieldValue);
               return (
-                plugin.name.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.description.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.author.toLowerCase().includes(searchFieldValue.toLowerCase()) ||
-                plugin.tags.some((tag: string) => tag.toLowerCase().includes(searchFieldValue.toLowerCase()))
+                normalizeForSearch(plugin.name).includes(query) ||
+                normalizeForSearch(plugin.description).includes(query) ||
+                normalizeForSearch(plugin.author).includes(query) ||
+                plugin.tags.some((tag: string) => normalizeForSearch(tag).includes(query))
               );
             })
             .map((plugin: StorePlugin) => (


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

The plugin store search used plain substring matching, so a query like `tab master` would not match a plugin named `tabmaster`. This normalizes both the search query and the searched fields (name, description, author, tags) by lowercasing and stripping whitespace before comparing.

Store search is performed entirely client-side (the remote store API returns the full list; only `sort_by`/`sort_direction` are sent), so this fix is contained to `frontend/src/components/store/Store.tsx`.

### Verification
- `pnpm run typecheck` — clean
- prettier — clean
- Logic check: `tab master`, `tabmaster`, `css`, `cssloader` all match `TabMaster`/`CSS Loader`; empty query still returns all plugins.

Resolves #622