### PR TITLE
feat: add offline install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,14 @@ For more information about Decky Loader as well as documentation and development
 
 - There is also a fast install for those who can use Konsole. Run `curl -L https://github.com/SteamDeckHomebrew/decky-installer/releases/latest/download/install_release.sh | sh` and type your password when prompted.
 
+### 📦 Offline Installation
+
+If you have limited internet access, you can install Decky Loader offline:
+
+1. Download the `PluginLoader` binary from the [releases page](https://github.com/SteamDeckHomebrew/decky-loader/releases) and the [`install_offline.sh`](./dist/install_offline.sh) script.
+2. Transfer both files to your Steam Deck (via USB, local network, etc).
+3. In Desktop Mode, open Konsole and run: `sudo sh install_offline.sh ./PluginLoader`
+
 ### 👋 Uninstallation
 
 We are sorry to see you go! If you are considering uninstalling because you are having issues, please consider [opening an issue](https://github.com/SteamDeckHomebrew/decky-loader/issues) or [joining our Discord](https://deckbrew.xyz/discord) so we can help you and other users.

--- a/dist/install_offline.sh
+++ b/dist/install_offline.sh
@@ -2,9 +2,14 @@
 
 set -e
 
-[ "$UID" -eq 0 ] || exec sudo "$0" "$@"
+# Resolve binary path to absolute before potential sudo re-exec
+if [ -n "$1" ] && [ -f "$1" ]; then
+    BINARY_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+else
+    BINARY_PATH="$1"
+fi
 
-BINARY_PATH="$1"
+[ "$UID" -eq 0 ] || exec sudo "$0" "$BINARY_PATH"
 
 if [ -z "$BINARY_PATH" ] || [ ! -f "$BINARY_PATH" ]; then
     echo "Usage: sudo $0 /path/to/PluginLoader"
@@ -27,16 +32,19 @@ fi
 
 HOMEBREW_FOLDER="${USER_DIR}/homebrew"
 
-# Stop existing service if running
-systemctl stop plugin_loader.service 2>/dev/null || true
-
 # Create directory structure
 mkdir -p "${HOMEBREW_FOLDER}/services/.systemd"
 mkdir -p "${HOMEBREW_FOLDER}/plugins"
 mkdir -p "${HOMEBREW_FOLDER}/settings"
 
+# Copy binary to temp location first to validate before stopping service
+cp "$BINARY_PATH" "${HOMEBREW_FOLDER}/services/PluginLoader.new"
+
+# Stop existing service if running (only after copy succeeded)
+systemctl stop plugin_loader.service 2>/dev/null || true
+
 # Install binary
-cp "$BINARY_PATH" "${HOMEBREW_FOLDER}/services/PluginLoader"
+mv "${HOMEBREW_FOLDER}/services/PluginLoader.new" "${HOMEBREW_FOLDER}/services/PluginLoader"
 chmod 755 "${HOMEBREW_FOLDER}/services/PluginLoader"
 
 # Handle SELinux
@@ -45,6 +53,7 @@ if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce)" = "Enforcing" ]; t
 fi
 
 # Install systemd service
+# Keep in sync with dist/plugin_loader-release.service
 cat > /etc/systemd/system/plugin_loader.service <<EOF
 [Unit]
 Description=SteamDeck Plugin Loader
@@ -55,8 +64,8 @@ User=root
 Restart=always
 KillMode=process
 TimeoutStopSec=15
-ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
-WorkingDirectory=${HOMEBREW_FOLDER}/services
+ExecStart="${HOMEBREW_FOLDER}/services/PluginLoader"
+WorkingDirectory="${HOMEBREW_FOLDER}/services"
 Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}
 Environment=PRIVILEGED_PATH=${HOMEBREW_FOLDER}
 Environment=LOG_LEVEL=INFO

--- a/dist/install_offline.sh
+++ b/dist/install_offline.sh
@@ -3,21 +3,30 @@
 set -e
 
 # Resolve binary path to absolute before potential sudo re-exec
-if [ -n "$1" ] && [ -f "$1" ]; then
-    BINARY_PATH="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+if [ -n "$1" ]; then
+    dir="$(cd "$(dirname "$1")" 2>/dev/null && pwd)" && BINARY_PATH="${dir}/$(basename "$1")" || BINARY_PATH="$1"
 else
-    BINARY_PATH="$1"
+    BINARY_PATH=""
 fi
 
-[ "$UID" -eq 0 ] || exec sudo "$0" "$BINARY_PATH"
+[ "$(id -u)" -eq 0 ] || exec sudo "$0" "$BINARY_PATH"
 
 if [ -z "$BINARY_PATH" ] || [ ! -f "$BINARY_PATH" ]; then
     echo "Usage: sudo $0 /path/to/PluginLoader"
-    echo ""
+    echo
     echo "Download the PluginLoader binary from:"
     echo "  https://github.com/SteamDeckHomebrew/decky-loader/releases"
     echo "Then run this script with the path to the downloaded binary."
     exit 1
+fi
+
+# Validate binary is an ELF executable
+if command -v file >/dev/null 2>&1; then
+    if ! file "$BINARY_PATH" | grep -qE 'ELF|executable'; then
+        echo "Error: $BINARY_PATH does not appear to be an executable binary."
+        echo "Make sure you downloaded the PluginLoader binary, not a zip or tarball."
+        exit 1
+    fi
 fi
 
 echo "Installing Decky Loader (offline)..."
@@ -30,6 +39,11 @@ else
     exit 1
 fi
 
+if [ -z "$USER_DIR" ] || [ ! -d "$USER_DIR" ]; then
+    echo "Error: Could not determine home directory for $SUDO_USER"
+    exit 1
+fi
+
 HOMEBREW_FOLDER="${USER_DIR}/homebrew"
 
 # Create directory structure
@@ -39,6 +53,14 @@ mkdir -p "${HOMEBREW_FOLDER}/settings"
 
 # Copy binary to temp location first to validate before stopping service
 cp "$BINARY_PATH" "${HOMEBREW_FOLDER}/services/PluginLoader.new"
+
+# Track whether service was running for rollback on failure
+SERVICE_WAS_RUNNING=false
+if systemctl is-active plugin_loader.service >/dev/null 2>&1; then
+    SERVICE_WAS_RUNNING=true
+fi
+
+trap 'if $SERVICE_WAS_RUNNING; then systemctl start plugin_loader.service 2>/dev/null || true; fi' EXIT
 
 # Stop existing service if running (only after copy succeeded)
 systemctl stop plugin_loader.service 2>/dev/null || true
@@ -76,16 +98,25 @@ EOF
 # Backup service file
 cp /etc/systemd/system/plugin_loader.service "${HOMEBREW_FOLDER}/services/.systemd/plugin_loader.service"
 
-# Set ownership (service runs as root but dirs should be user-owned)
-chown -R "$SUDO_USER":"$SUDO_USER" "${HOMEBREW_FOLDER}"
+# Set ownership — plugins/settings are user-owned, but services/PluginLoader must stay root-owned
+chown -R "$SUDO_USER":"$SUDO_USER" "${HOMEBREW_FOLDER}/plugins"
+chown -R "$SUDO_USER":"$SUDO_USER" "${HOMEBREW_FOLDER}/settings"
+chown "$SUDO_USER":"$SUDO_USER" "${HOMEBREW_FOLDER}"
+
+# Binary and services dir stay root-owned (service runs as root — user-writable binary = privesc)
+chown root:root "${HOMEBREW_FOLDER}/services/PluginLoader"
+chmod 755 "${HOMEBREW_FOLDER}/services/PluginLoader"
 
 # Enable and start
 systemctl daemon-reload
 systemctl enable --now plugin_loader.service
 
-echo ""
+# Clear rollback trap — install succeeded
+trap - EXIT
+
+echo
 echo "Decky Loader installed successfully!"
 echo "  Install path: ${HOMEBREW_FOLDER}"
 echo "  Service: plugin_loader.service (running)"
-echo ""
+echo
 echo "Return to Gaming Mode to use Decky."

--- a/dist/install_offline.sh
+++ b/dist/install_offline.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+set -e
+
+[ "$UID" -eq 0 ] || exec sudo "$0" "$@"
+
+BINARY_PATH="$1"
+
+if [ -z "$BINARY_PATH" ] || [ ! -f "$BINARY_PATH" ]; then
+    echo "Usage: sudo $0 /path/to/PluginLoader"
+    echo ""
+    echo "Download the PluginLoader binary from:"
+    echo "  https://github.com/SteamDeckHomebrew/decky-loader/releases"
+    echo "Then run this script with the path to the downloaded binary."
+    exit 1
+fi
+
+echo "Installing Decky Loader (offline)..."
+
+# Detect user home directory
+if [ -n "$SUDO_USER" ]; then
+    USER_DIR="$(getent passwd "$SUDO_USER" | cut -d: -f6)"
+else
+    echo "Error: Could not detect user. Run with sudo (not as root directly)."
+    exit 1
+fi
+
+HOMEBREW_FOLDER="${USER_DIR}/homebrew"
+
+# Stop existing service if running
+systemctl stop plugin_loader.service 2>/dev/null || true
+
+# Create directory structure
+mkdir -p "${HOMEBREW_FOLDER}/services/.systemd"
+mkdir -p "${HOMEBREW_FOLDER}/plugins"
+mkdir -p "${HOMEBREW_FOLDER}/settings"
+
+# Install binary
+cp "$BINARY_PATH" "${HOMEBREW_FOLDER}/services/PluginLoader"
+chmod 755 "${HOMEBREW_FOLDER}/services/PluginLoader"
+
+# Handle SELinux
+if command -v getenforce >/dev/null 2>&1 && [ "$(getenforce)" = "Enforcing" ]; then
+    chcon -t bin_t "${HOMEBREW_FOLDER}/services/PluginLoader"
+fi
+
+# Install systemd service
+cat > /etc/systemd/system/plugin_loader.service <<EOF
+[Unit]
+Description=SteamDeck Plugin Loader
+After=network.target
+[Service]
+Type=simple
+User=root
+Restart=always
+KillMode=process
+TimeoutStopSec=15
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
+Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}
+Environment=PRIVILEGED_PATH=${HOMEBREW_FOLDER}
+Environment=LOG_LEVEL=INFO
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Backup service file
+cp /etc/systemd/system/plugin_loader.service "${HOMEBREW_FOLDER}/services/.systemd/plugin_loader.service"
+
+# Set ownership (service runs as root but dirs should be user-owned)
+chown -R "$SUDO_USER":"$SUDO_USER" "${HOMEBREW_FOLDER}"
+
+# Enable and start
+systemctl daemon-reload
+systemctl enable --now plugin_loader.service
+
+echo ""
+echo "Decky Loader installed successfully!"
+echo "  Install path: ${HOMEBREW_FOLDER}"
+echo "  Service: plugin_loader.service (running)"
+echo ""
+echo "Return to Gaming Mode to use Decky."

--- a/dist/install_offline.sh
+++ b/dist/install_offline.sh
@@ -64,8 +64,8 @@ User=root
 Restart=always
 KillMode=process
 TimeoutStopSec=15
-ExecStart="${HOMEBREW_FOLDER}/services/PluginLoader"
-WorkingDirectory="${HOMEBREW_FOLDER}/services"
+ExecStart=${HOMEBREW_FOLDER}/services/PluginLoader
+WorkingDirectory=${HOMEBREW_FOLDER}/services
 Environment=UNPRIVILEGED_PATH=${HOMEBREW_FOLDER}
 Environment=PRIVILEGED_PATH=${HOMEBREW_FOLDER}
 Environment=LOG_LEVEL=INFO


### PR DESCRIPTION
## Summary

- Adds `dist/install_offline.sh` — a self-contained offline installer for users with limited internet access
- Adds "Offline Installation" section to README with 3-step instructions

Closes #924

## Usage

```bash
sudo sh install_offline.sh ./PluginLoader
```

User downloads the `PluginLoader` binary from releases (via mirror, VPN, or patience), transfers it to the Steam Deck, and runs the script. No network required.

## What the script does

1. Resolves binary path to absolute (safe across sudo re-exec)
2. Detects user home directory via `$SUDO_USER`
3. Creates `~/homebrew/{services,plugins,settings}` directory structure
4. Copies binary (validates copy before stopping existing service)
5. Handles SELinux if enforcing
6. Installs systemd service from embedded template
7. Enables and starts `plugin_loader.service`

## Test plan

- [ ] Run on SteamOS with a downloaded PluginLoader binary
- [ ] Verify service starts and Decky is accessible in Gaming Mode
- [ ] Run twice (idempotent — no errors on re-install)
- [ ] Verify `dist/uninstall.sh` still works after offline install
- [ ] Test with disk-full simulation (service should NOT be left stopped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)