### PR TITLE
fix: align plugin install progress

### DIFF
--- a/frontend/src/components/modals/MultiplePluginsInstallModal.tsx
+++ b/frontend/src/components/modals/MultiplePluginsInstallModal.tsx
@@ -1,9 +1,10 @@
-import { ConfirmModal, Navigation, ProgressBarWithInfo, QuickAccessTab } from '@decky/ui';
+import { ConfirmModal, Navigation, QuickAccessTab } from '@decky/ui';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FaCheck, FaDownload } from 'react-icons/fa';
 
 import { DisabledPlugin, InstallType, InstallTypeTranslationMapping } from '../../plugin';
+import PluginInstallProgress from './PluginInstallProgress';
 
 interface MultiplePluginsInstallModalProps {
   requests: { name: string; version: string; hash: string; install_type: InstallType }[];
@@ -132,15 +133,12 @@ const MultiplePluginsInstallModal: FC<MultiplePluginsInstallModalProps> = ({
             );
           })}
         </ul>
-        {/* TODO: center the progress bar and make it 80% width */}
         {loading && (
-          <ProgressBarWithInfo
+          <PluginInstallProgress
             // when the key changes, react considers this a new component so resets the progress without the smoothing animation
             key={pluginInProgress}
-            bottomSeparator="none"
-            focusable={false}
-            nProgress={percentage}
-            sOperationText={downloadInfo}
+            percentage={percentage}
+            operationText={downloadInfo}
           />
         )}
       </div>

--- a/frontend/src/components/modals/PluginInstallModal.tsx
+++ b/frontend/src/components/modals/PluginInstallModal.tsx
@@ -1,8 +1,9 @@
-import { ConfirmModal, Navigation, ProgressBarWithInfo, QuickAccessTab } from '@decky/ui';
+import { ConfirmModal, Navigation, QuickAccessTab } from '@decky/ui';
 import { FC, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { InstallType, InstallTypeTranslationMapping } from '../../plugin';
+import PluginInstallProgress from './PluginInstallProgress';
 
 interface PluginInstallModalProps {
   artifact: string;
@@ -66,7 +67,7 @@ const PluginInstallModal: FC<PluginInstallModalProps> = ({
         await onCancel();
       }}
       strTitle={
-        <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'center', width: '100%' }}>
+        <div>
           {
             // IMPORTANT! These comments are not cosmetic and are needed for `extracttext` task to work
             // t('PluginInstallModal.install.title')
@@ -76,16 +77,6 @@ const PluginInstallModal: FC<PluginInstallModalProps> = ({
             // t('PluginInstallModal.overwrite.title')
             t(`PluginInstallModal.${installTypeTranslationKey}.title`, { artifact: artifact })
           }
-          {loading && (
-            <div style={{ marginLeft: 'auto' }}>
-              <ProgressBarWithInfo
-                layout="inline"
-                bottomSeparator="none"
-                nProgress={percentage}
-                sOperationText={downloadInfo}
-              />
-            </div>
-          )}
         </div>
       }
       strOKButtonText={
@@ -128,6 +119,7 @@ const PluginInstallModal: FC<PluginInstallModalProps> = ({
         }
       </div>
       {hash == 'False' && <span style={{ color: 'red' }}>{t('PluginInstallModal.no_hash')}</span>}
+      {loading && <PluginInstallProgress percentage={percentage} operationText={downloadInfo} />}
     </ConfirmModal>
   );
 };

--- a/frontend/src/components/modals/PluginInstallProgress.tsx
+++ b/frontend/src/components/modals/PluginInstallProgress.tsx
@@ -1,0 +1,31 @@
+import { Field, ProgressBar } from '@decky/ui';
+import { FC } from 'react';
+
+interface PluginInstallProgressProps {
+  percentage: number;
+  operationText: string | null;
+}
+
+const PluginInstallProgress: FC<PluginInstallProgressProps> = ({ percentage, operationText }) => {
+  return (
+    <div style={{ width: '100%', margin: '16px 0 0' }}>
+      <Field bottomSeparator="none" childrenLayout="below" focusable={false} padding="standard">
+        <div style={{ width: '100%' }}>
+          <div
+            style={{
+              minHeight: '22px',
+              width: '100%',
+              textAlign: 'left',
+              textTransform: 'uppercase',
+            }}
+          >
+            {operationText}
+          </div>
+          <ProgressBar focusable={false} nProgress={percentage} />
+        </div>
+      </Field>
+    </div>
+  );
+};
+
+export default PluginInstallProgress;


### PR DESCRIPTION
Please tick as appropriate:

  - [x] I have tested this code on a Steam Deck or on a PC
  - [x] My changes generate no new errors/warnings
  - [x] This is a bugfix/hotfix
  - [ ] This is a new feature

  # Description

  Moves plugin installation progress out of the dialog title and into a shared, full-width progress panel below the description.

  Previously, the progress widget used an inline, fixed-width layout that pushed the operation text to the right and caused the progress bar to overflow or shift as the text changed.

  The new progress panel:

  - Spans the modal content width, aligning with the outer edges of the dialog buttons.
  - Left-aligns the operation text.
  - Keeps the progress bar within the panel’s standard padding.
  - Uses Decky’s native Field and ProgressBar components.
  - Shares the same layout between single-plugin and multi-plugin installations.

<img width="640" height="360" alt="Screencast_20260715_130437" src="https://github.com/user-attachments/assets/bdcf90cc-6c42-4aa2-b32f-9ad211f87bbf" />



  This fixes issue: #943