### PR TITLE
fix: support renamed Steam initialization API

### DIFF
--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -1,12 +1,21 @@
 // Sets up DFL, then loads start.ts which starts up the loader
 
+interface SteamAppInitialization {
+  BFinishedInitBeforeLogin?: () => boolean;
+  BFinishedInitStageOne?: () => boolean;
+}
+
+const isSteamAppInitialized = () => {
+  const app = window.App as unknown as SteamAppInitialization | undefined;
+  return app?.BFinishedInitBeforeLogin?.() ?? app?.BFinishedInitStageOne?.() ?? false;
+};
+
 (async () => {
   console.debug('[Decky:Boot] Frontend init');
 
   console.time('[Decky:Boot] Waiting for SteamApp init stage 1 to finish...');
 
-  // @ts-expect-error TODO type BFinishedInitStageOne in @decky/ui
-  while (!window.App?.BFinishedInitStageOne()) {
+  while (!isSteamAppInitialized()) {
     await new Promise((r) => setTimeout(r, 0)); // Can't use DFL sleep here.
   }
 


### PR DESCRIPTION
Please tick as appropriate:
- [x] I have tested this code on a steam deck or on a PC
  - Tested on https://github.com/virtudude/armada with the pre and post rename Steam client versions
- [x] My changes generate no new errors/warnings
- [x] This is a bugfix/hotfix
- [ ] This is a new feature

# Description

Steam renamed `BFinishedInitStageOne` to `BFinishedInitBeforeLogin` in client version `1784934043`, preventing Decky’s frontend from loading on newer clients. This updates the initialization check to use the new API.